### PR TITLE
Actually return failing code

### DIFF
--- a/src/dayamlchecker/__main__.py
+++ b/src/dayamlchecker/__main__.py
@@ -1,3 +1,5 @@
 from .yaml_structure import main
 
-main()
+import sys
+
+sys.exit(main())

--- a/src/dayamlchecker/generate_mcp_config.py
+++ b/src/dayamlchecker/generate_mcp_config.py
@@ -147,4 +147,4 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    sys.exit(main())

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -1148,7 +1148,11 @@ def _collect_yaml_files(
     return _formatter_collect(paths, include_default_ignores=include_default_ignores)
 
 
-def process_file(input_file):
+def process_file(input_file) -> int:
+    """
+    Returns:
+        int: the number of errors found in the input_file
+    """
     for dumb_da_file in [
         "pgcodecache.yml",
         "title_documentation.yml",
@@ -1160,17 +1164,18 @@ def process_file(input_file):
         if input_file.endswith(dumb_da_file):
             print()
             print(f"ignoring {dumb_da_file}")
-            return
+            return 0
 
     all_errors = find_errors(input_file)
 
     if len(all_errors) == 0:
         print(".", end="")
-        return
+        return 0
     print()
     print(f"Found {len(all_errors)} errors:")
     for err in all_errors:
         print(f"{err}")
+    return len(all_errors)
 
 
 def main() -> int:
@@ -1200,9 +1205,12 @@ def main() -> int:
         print("No YAML files found.", file=sys.stderr)
         return 1
 
+    failed = False
     for input_file in yaml_files:
-        process_file(str(input_file))
-    return 0
+        error_count = process_file(str(input_file))
+        if error_count > 0:
+            failed = True
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* If any of the input files processed have an error, returns an exit code of 1
    * necessary to properly integrate with GitHub actions
* works with `dayamlchecker` and `python -m dayamlchecker`

Originally noticed this in https://github.com/SuffolkLITLab/docassemble-ssareportchangesletter/pull/75, but thought it was already fix and just needed to be released.