### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dayamlchecker"
-version = "1.0.0"
+version = "1.1.0"
 description = "An LSP for Docassemble YAML interviews"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Since the last version, have added recursive directory parsing,
which is a pretty major feature and change in the CLI, so bumping the
minor version. Does still work when passed individual files though,
so not a breaking change.

Trying to make the dabuild action properly report errors, now that #15 is in.

Locally confirmed that this version works with how the `dabuild` action calls it.