### PR TITLE
Do not error on commented out URLs or multi-line URLs that are identified by Acrobat and Chrome

### DIFF
--- a/src/dayamlchecker/check_questions_urls.py
+++ b/src/dayamlchecker/check_questions_urls.py
@@ -62,6 +62,8 @@ class URLSourceCollection:
     document_urls: dict[str, set[str]]
     yaml_concatenated: dict[str, set[str]]
     document_concatenated: dict[str, set[str]]
+    yaml_repairs: dict[str, set[str]]
+    document_repairs: dict[str, set[str]]
 
     @property
     def unique_url_count(self) -> int:
@@ -161,6 +163,8 @@ _YAML_PYTHON_BLOCK_KEYS: frozenset[str] = frozenset({"code"})
 _YAML_BLOCK_SCALAR_RE = re.compile(
     r"^\s*(?:-\s*)?(?P<key>[^#:\n][^:\n]*):\s*[>|][^\n]*$"
 )
+_URL_CONTINUATION_CHARS: frozenset[str] = frozenset("-_/=&%?#")
+_URL_LEADING_TOKEN_RE = re.compile(r"^([A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+)")
 
 
 def _iter_package_dirs(
@@ -405,6 +409,38 @@ def _strip_python_comments(text: str) -> str:
     return tokenize.untokenize(output)
 
 
+def _extract_wrapped_pdf_url_repairs(text: str) -> dict[str, set[str]]:
+    lines = text.splitlines(keepends=True)
+    if len(lines) < 2:
+        return {}
+
+    repairs: dict[str, set[str]] = defaultdict(set)
+    previous = lines[0]
+    for line in lines[1:]:
+        stripped_previous = previous.rstrip("\r\n")
+        trailing_match = re.search(r"(https?://\S+)$", stripped_previous)
+        leading_match = _URL_LEADING_TOKEN_RE.match(line.lstrip())
+        if (
+            trailing_match is not None
+            and leading_match is not None
+            and trailing_match.group(1)[-1] in _URL_CONTINUATION_CHARS
+        ):
+            original_url, is_concatenated = parse_url_token(trailing_match.group(1))
+            repaired_url, repaired_is_concatenated = parse_url_token(
+                trailing_match.group(1) + leading_match.group(1)
+            )
+            if (
+                original_url
+                and repaired_url
+                and not is_concatenated
+                and not repaired_is_concatenated
+                and repaired_url != original_url
+            ):
+                repairs[original_url].add(repaired_url)
+        previous = line
+    return repairs
+
+
 def _strip_python_comments_from_indented_block(lines: list[str]) -> str:
     nonempty_lines = [line for line in lines if line.strip()]
     if not nonempty_lines:
@@ -502,10 +538,19 @@ def _prepare_text_for_url_extraction(file_path: pathlib.Path, text: str) -> str:
 def extract_urls_from_file(
     file_path: pathlib.Path, linkify: LinkifyIt
 ) -> tuple[list[str], list[str]]:
+    urls, concatenated_urls, _ = _extract_urls_from_file_detailed(file_path, linkify)
+    return urls, concatenated_urls
+
+
+def _extract_urls_from_file_detailed(
+    file_path: pathlib.Path, linkify: LinkifyIt
+) -> tuple[list[str], list[str], dict[str, set[str]]]:
     # Extract text based on file type
     suffix = file_path.suffix.lower()
+    repair_candidates: dict[str, set[str]] = {}
     if suffix == ".pdf":
         text = extract_text_from_pdf(file_path)
+        repair_candidates = _extract_wrapped_pdf_url_repairs(text)
     elif suffix == ".docx":
         text = extract_text_from_docx(file_path)
     else:
@@ -514,10 +559,10 @@ def extract_urls_from_file(
             text = file_path.read_text(encoding="utf-8")
         except UnicodeDecodeError:
             # Skip non-text files in questions directories.
-            return [], []
+            return [], [], {}
 
     if not text:
-        return [], []
+        return [], [], {}
 
     text = _prepare_text_for_url_extraction(file_path, text)
 
@@ -534,7 +579,7 @@ def extract_urls_from_file(
         if is_reserved_example_domain(url):
             continue
         found_urls.append(url)
-    return found_urls, concatenated_urls
+    return found_urls, concatenated_urls, repair_candidates
 
 
 def _display_path(file_path: pathlib.Path, root: pathlib.Path) -> str:
@@ -546,18 +591,23 @@ def _display_path(file_path: pathlib.Path, root: pathlib.Path) -> str:
 
 def collect_urls_from_files(
     file_paths: Iterable[pathlib.Path], root: pathlib.Path
-) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+) -> tuple[dict[str, set[str]], dict[str, set[str]], dict[str, set[str]]]:
     linkify = LinkifyIt(options={"fuzzy_link": False})
     url_sources: dict[str, set[str]] = defaultdict(set)
     concatenated_sources: dict[str, set[str]] = defaultdict(set)
+    repair_candidates: dict[str, set[str]] = defaultdict(set)
     for file_path in file_paths:
         rel_path = _display_path(file_path, root)
-        urls, concatenated_urls = extract_urls_from_file(file_path, linkify)
+        urls, concatenated_urls, file_repairs = _extract_urls_from_file_detailed(
+            file_path, linkify
+        )
         for url in urls:
             url_sources[url].add(rel_path)
         for bad_url in concatenated_urls:
             concatenated_sources[bad_url].add(rel_path)
-    return url_sources, concatenated_sources
+        for url, candidates in file_repairs.items():
+            repair_candidates[url].update(candidates)
+    return url_sources, concatenated_sources, repair_candidates
 
 
 def collect_urls(
@@ -569,12 +619,15 @@ def collect_urls(
     if question_files is None:
         question_files = iter_question_files(root, package_dirs=package_dirs)
 
-    yaml_urls, yaml_concatenated = collect_urls_from_files(question_files, root)
+    yaml_urls, yaml_concatenated, yaml_repairs = collect_urls_from_files(
+        question_files, root
+    )
 
     document_urls: dict[str, set[str]] = {}
     document_concatenated: dict[str, set[str]] = {}
+    document_repairs: dict[str, set[str]] = {}
     if check_documents:
-        document_urls, document_concatenated = collect_urls_from_files(
+        document_urls, document_concatenated, document_repairs = collect_urls_from_files(
             iter_document_files(root, package_dirs=package_dirs), root
         )
 
@@ -583,14 +636,35 @@ def collect_urls(
         document_urls=document_urls,
         yaml_concatenated=yaml_concatenated,
         document_concatenated=document_concatenated,
+        yaml_repairs=yaml_repairs,
+        document_repairs=document_repairs,
     )
 
 
 _DEAD_STATUS_CODES: frozenset[int] = frozenset({404, 410})
 
 
+def _check_single_url(
+    session: requests.Session,
+    url: str,
+    timeout: int,
+    *,
+    report_unreachable: bool = True,
+) -> tuple[int | None, bool]:
+    try:
+        with session.get(url, allow_redirects=True, timeout=timeout, stream=True) as response:
+            return response.status_code, False
+    except requests.RequestException as exc:
+        if report_unreachable:
+            print(f"Warning: could not check {url}: {exc}", file=sys.stderr)
+        return None, True
+
+
 def check_urls(
-    session: requests.Session, urls: Iterable[str], timeout: int
+    session: requests.Session,
+    urls: Iterable[str],
+    timeout: int,
+    repair_candidates: dict[str, set[str]] | None = None,
 ) -> tuple[list[tuple[str, int]], list[str]]:
     """Return (broken, unreachable) for the given *urls*.
 
@@ -604,17 +678,29 @@ def check_urls(
         if is_whitelisted_url(url):
             continue
 
-        try:
-            # stream=True avoids downloading large response bodies; the
-            # context manager ensures the connection is released promptly.
-            with session.get(
-                url, allow_redirects=True, timeout=timeout, stream=True
-            ) as response:
-                if response.status_code in _DEAD_STATUS_CODES:
-                    broken.append((url, response.status_code))
-        except requests.RequestException as exc:
-            print(f"Warning: could not check {url}: {exc}", file=sys.stderr)
+        status_code, was_unreachable = _check_single_url(session, url, timeout)
+        if was_unreachable:
             unreachable.append(url)
+            continue
+        if status_code not in _DEAD_STATUS_CODES:
+            continue
+
+        repaired = False
+        for candidate in sorted((repair_candidates or {}).get(url, ())):
+            if is_whitelisted_url(candidate):
+                repaired = True
+                break
+            candidate_status, candidate_unreachable = _check_single_url(
+                session,
+                candidate,
+                timeout,
+                report_unreachable=False,
+            )
+            if not candidate_unreachable and candidate_status not in _DEAD_STATUS_CODES:
+                repaired = True
+                break
+        if not repaired:
+            broken.append((url, status_code))
     return broken, unreachable
 
 
@@ -720,7 +806,16 @@ def run_url_check(
     unreachable: list[str] = []
     if urls_to_check:
         session = build_session()
-        broken, unreachable = check_urls(session, urls_to_check, timeout)
+        broken, unreachable = check_urls(
+            session,
+            urls_to_check,
+            timeout,
+            repair_candidates={
+                url: set(collected.yaml_repairs.get(url, set()))
+                | set(collected.document_repairs.get(url, set()))
+                for url in urls_to_check
+            },
+        )
 
     for url, status_code in broken:
         if url in collected.yaml_urls:

--- a/src/dayamlchecker/check_questions_urls.py
+++ b/src/dayamlchecker/check_questions_urls.py
@@ -8,9 +8,11 @@ import os
 import pathlib
 import re
 import sys
+import tokenize
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
+from io import StringIO
 from typing import Literal
 from urllib.parse import urlparse
 
@@ -153,6 +155,11 @@ _WHITELIST_URL_PREFIXES: frozenset[str] = frozenset(
         "https://api.openai.com/v1/",
         "https://generativelanguage.googleapis.com/v1beta/openai/",
     }
+)
+
+_YAML_PYTHON_BLOCK_KEYS: frozenset[str] = frozenset({"code"})
+_YAML_BLOCK_SCALAR_RE = re.compile(
+    r"^\s*(?:-\s*)?(?P<key>[^#:\n][^:\n]*):\s*[>|][^\n]*$"
 )
 
 
@@ -385,6 +392,113 @@ def parse_ignore_urls(raw: str) -> set[str]:
     return ignored_urls
 
 
+def _strip_python_comments(text: str) -> str:
+    output: list[tokenize.TokenInfo] = []
+    try:
+        for token in tokenize.generate_tokens(StringIO(text).readline):
+            if token.type == tokenize.COMMENT:
+                continue
+            output.append(token)
+    except tokenize.TokenError:
+        # Fall back to the original text when tokenization fails on incomplete code.
+        return text
+    return tokenize.untokenize(output)
+
+
+def _strip_python_comments_from_indented_block(lines: list[str]) -> str:
+    nonempty_lines = [line for line in lines if line.strip()]
+    if not nonempty_lines:
+        return "".join(lines)
+
+    min_indent = min(len(line) - len(line.lstrip(" ")) for line in nonempty_lines)
+    dedented = "".join(
+        line[min_indent:] if line.strip() else line for line in lines
+    )
+    stripped = _strip_python_comments(dedented)
+    return "".join(
+        (" " * min_indent + line if line.strip() else line)
+        for line in stripped.splitlines(keepends=True)
+    )
+
+
+def _yaml_block_scalar_mode(line: str) -> str | None:
+    match = _YAML_BLOCK_SCALAR_RE.match(line.rstrip())
+    if match is None:
+        return None
+    key = match.group("key").strip().lower()
+    if key in _YAML_PYTHON_BLOCK_KEYS:
+        return "python"
+    return "raw"
+
+
+def _strip_yaml_comments(text: str) -> str:
+    block_scalar_indent: int | None = None
+    block_scalar_mode: str | None = None
+    block_scalar_lines: list[str] = []
+    stripped_lines: list[str] = []
+
+    def flush_block_scalar() -> None:
+        nonlocal block_scalar_indent, block_scalar_mode, block_scalar_lines
+        if block_scalar_mode == "python":
+            stripped_lines.append(_strip_python_comments_from_indented_block(block_scalar_lines))
+        else:
+            stripped_lines.extend(block_scalar_lines)
+        block_scalar_indent = None
+        block_scalar_mode = None
+        block_scalar_lines = []
+
+    for line in text.splitlines(keepends=True):
+        line_without_newline = line.rstrip("\r\n")
+        indentation = len(line_without_newline) - len(line_without_newline.lstrip(" "))
+        stripped_content = line_without_newline.strip()
+
+        if block_scalar_indent is not None:
+            if stripped_content and indentation <= block_scalar_indent:
+                flush_block_scalar()
+            else:
+                block_scalar_lines.append(line)
+                continue
+
+        in_single = False
+        in_double = False
+        result: list[str] = []
+        for index, char in enumerate(line):
+            prev_char = line[index - 1] if index > 0 else ""
+            if char == "'" and not in_double:
+                in_single = not in_single
+                result.append(char)
+                continue
+            if char == '"' and not in_single and prev_char != "\\":
+                in_double = not in_double
+                result.append(char)
+                continue
+            if (
+                char == "#"
+                and not in_single
+                and not in_double
+                and (index == 0 or line[index - 1].isspace())
+            ):
+                break
+            result.append(char)
+        stripped_line = "".join(result)
+        stripped_lines.append(stripped_line)
+        block_scalar_mode = _yaml_block_scalar_mode(stripped_line)
+        if block_scalar_mode is not None:
+            block_scalar_indent = indentation
+    if block_scalar_indent is not None:
+        flush_block_scalar()
+    return "".join(stripped_lines)
+
+
+def _prepare_text_for_url_extraction(file_path: pathlib.Path, text: str) -> str:
+    suffix = file_path.suffix.lower()
+    if suffix == ".py":
+        return _strip_python_comments(text)
+    if suffix in {".yml", ".yaml"}:
+        return _strip_yaml_comments(text)
+    return text
+
+
 def extract_urls_from_file(
     file_path: pathlib.Path, linkify: LinkifyIt
 ) -> tuple[list[str], list[str]]:
@@ -404,6 +518,8 @@ def extract_urls_from_file(
 
     if not text:
         return [], []
+
+    text = _prepare_text_for_url_extraction(file_path, text)
 
     matches = linkify.match(text) or []
     found_urls: list[str] = []

--- a/src/dayamlchecker/check_questions_urls.py
+++ b/src/dayamlchecker/check_questions_urls.py
@@ -465,11 +465,22 @@ def _yaml_block_scalar_mode(line: str) -> str | None:
     return "raw"
 
 
+def _is_unescaped_double_quote(line: str, index: int) -> bool:
+    backslash_count = 0
+    scan_index = index - 1
+    while scan_index >= 0 and line[scan_index] == "\\":
+        backslash_count += 1
+        scan_index -= 1
+    return backslash_count % 2 == 0
+
+
 def _strip_yaml_comments(text: str) -> str:
     block_scalar_indent: int | None = None
     block_scalar_mode: str | None = None
     block_scalar_lines: list[str] = []
     stripped_lines: list[str] = []
+    in_single = False
+    in_double = False
 
     def flush_block_scalar() -> None:
         nonlocal block_scalar_indent, block_scalar_mode, block_scalar_lines
@@ -495,18 +506,27 @@ def _strip_yaml_comments(text: str) -> str:
                 block_scalar_lines.append(line)
                 continue
 
-        in_single = False
-        in_double = False
         result: list[str] = []
-        for index, char in enumerate(line):
-            prev_char = line[index - 1] if index > 0 else ""
+        index = 0
+        while index < len(line):
+            char = line[index]
             if char == "'" and not in_double:
+                if in_single and index + 1 < len(line) and line[index + 1] == "'":
+                    result.append("''")
+                    index += 2
+                    continue
                 in_single = not in_single
                 result.append(char)
+                index += 1
                 continue
-            if char == '"' and not in_single and prev_char != "\\":
+            if (
+                char == '"'
+                and not in_single
+                and _is_unescaped_double_quote(line, index)
+            ):
                 in_double = not in_double
                 result.append(char)
+                index += 1
                 continue
             if (
                 char == "#"
@@ -516,6 +536,7 @@ def _strip_yaml_comments(text: str) -> str:
             ):
                 break
             result.append(char)
+            index += 1
         stripped_line = "".join(result)
         stripped_lines.append(stripped_line)
         block_scalar_mode = _yaml_block_scalar_mode(stripped_line)

--- a/src/dayamlchecker/check_questions_urls.py
+++ b/src/dayamlchecker/check_questions_urls.py
@@ -447,9 +447,7 @@ def _strip_python_comments_from_indented_block(lines: list[str]) -> str:
         return "".join(lines)
 
     min_indent = min(len(line) - len(line.lstrip(" ")) for line in nonempty_lines)
-    dedented = "".join(
-        line[min_indent:] if line.strip() else line for line in lines
-    )
+    dedented = "".join(line[min_indent:] if line.strip() else line for line in lines)
     stripped = _strip_python_comments(dedented)
     return "".join(
         (" " * min_indent + line if line.strip() else line)
@@ -476,7 +474,9 @@ def _strip_yaml_comments(text: str) -> str:
     def flush_block_scalar() -> None:
         nonlocal block_scalar_indent, block_scalar_mode, block_scalar_lines
         if block_scalar_mode == "python":
-            stripped_lines.append(_strip_python_comments_from_indented_block(block_scalar_lines))
+            stripped_lines.append(
+                _strip_python_comments_from_indented_block(block_scalar_lines)
+            )
         else:
             stripped_lines.extend(block_scalar_lines)
         block_scalar_indent = None
@@ -627,8 +627,10 @@ def collect_urls(
     document_concatenated: dict[str, set[str]] = {}
     document_repairs: dict[str, set[str]] = {}
     if check_documents:
-        document_urls, document_concatenated, document_repairs = collect_urls_from_files(
-            iter_document_files(root, package_dirs=package_dirs), root
+        document_urls, document_concatenated, document_repairs = (
+            collect_urls_from_files(
+                iter_document_files(root, package_dirs=package_dirs), root
+            )
         )
 
     return URLSourceCollection(
@@ -652,7 +654,9 @@ def _check_single_url(
     report_unreachable: bool = True,
 ) -> tuple[int | None, bool]:
     try:
-        with session.get(url, allow_redirects=True, timeout=timeout, stream=True) as response:
+        with session.get(
+            url, allow_redirects=True, timeout=timeout, stream=True
+        ) as response:
             return response.status_code, False
     except requests.RequestException as exc:
         if report_unreachable:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import sys
 from pathlib import Path
 
-
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 

--- a/tests/test_check_questions_urls.py
+++ b/tests/test_check_questions_urls.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 from linkify_it import LinkifyIt
 
-from dayamlchecker.check_questions_urls import extract_urls_from_file
+import dayamlchecker.check_questions_urls as check_questions_urls
+from dayamlchecker.check_questions_urls import check_urls, extract_text_from_pdf, extract_urls_from_file
 
 
 def test_extract_urls_skips_python_comment_urls(tmp_path: Path) -> None:
@@ -143,3 +144,89 @@ def test_extract_urls_skips_python_comment_urls_in_code_block_scalar(
 
     assert urls == ["https://live.example/value"]
     assert concatenated == []
+
+
+def test_extract_text_from_pdf_keeps_wrapped_urls_in_raw_text(
+    tmp_path: Path, monkeypatch
+) -> None:
+    file_path = tmp_path / "example.pdf"
+    file_path.write_bytes(b"%PDF-1.4\n")
+
+    class FakePage:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def extract_text(self) -> str:
+            return self.text
+
+    class FakeReader:
+        def __init__(self, _: Path) -> None:
+            self.pages = [
+                FakePage(
+                    "Visit https://www.courts.michigan.gov/49752a/siteassets/forms/scao-\n"
+                    "approved/dhs1201d.pdf for the full form."
+                )
+            ]
+
+    monkeypatch.setattr(check_questions_urls, "PdfReader", FakeReader)
+
+    assert extract_text_from_pdf(file_path) == (
+        "Visit https://www.courts.michigan.gov/49752a/siteassets/forms/scao-\n"
+        "approved/dhs1201d.pdf for the full form."
+    )
+
+
+def test_extract_wrapped_pdf_url_repairs_finds_joined_candidate() -> None:
+    repairs = check_questions_urls._extract_wrapped_pdf_url_repairs(
+        "Visit https://www.courts.michigan.gov/49752a/siteassets/forms/scao-\n"
+        "approved/dhs1201d.pdf for the full form."
+    )
+
+    assert repairs == {
+        "https://www.courts.michigan.gov/49752a/siteassets/forms/scao-": {
+            "https://www.courts.michigan.gov/49752a/siteassets/forms/scao-approved/dhs1201d.pdf"
+        }
+    }
+
+
+def test_check_urls_tries_pdf_repair_candidates_after_dead_link() -> None:
+    class FakeResponse:
+        def __init__(self, status_code: int) -> None:
+            self.status_code = status_code
+
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    class FakeSession:
+        def __init__(self) -> None:
+            self.calls: list[str] = []
+
+        def get(self, url: str, **kwargs) -> FakeResponse:
+            self.calls.append(url)
+            if url.endswith("scao-"):
+                return FakeResponse(404)
+            if url.endswith("dhs1201d.pdf"):
+                return FakeResponse(200)
+            raise AssertionError(url)
+
+    session = FakeSession()
+    broken, unreachable = check_urls(
+        session,
+        ["https://www.courts.michigan.gov/49752a/siteassets/forms/scao-"],
+        timeout=10,
+        repair_candidates={
+            "https://www.courts.michigan.gov/49752a/siteassets/forms/scao-": {
+                "https://www.courts.michigan.gov/49752a/siteassets/forms/scao-approved/dhs1201d.pdf"
+            }
+        },
+    )
+
+    assert broken == []
+    assert unreachable == []
+    assert session.calls == [
+        "https://www.courts.michigan.gov/49752a/siteassets/forms/scao-",
+        "https://www.courts.michigan.gov/49752a/siteassets/forms/scao-approved/dhs1201d.pdf",
+    ]

--- a/tests/test_check_questions_urls.py
+++ b/tests/test_check_questions_urls.py
@@ -55,6 +55,56 @@ def test_extract_urls_skips_yaml_comment_urls(tmp_path: Path) -> None:
     assert concatenated == []
 
 
+def test_extract_urls_keeps_urls_in_multiline_double_quoted_yaml_scalar(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "example.yml"
+    file_path.write_text(
+        "\n".join(
+            [
+                'note: "first line',
+                "  https://live.example/double-quoted",
+                '  # still content"',
+                "field: value # https://commented.example/trailing",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    urls, concatenated = extract_urls_from_file(
+        file_path, LinkifyIt(options={"fuzzy_link": False})
+    )
+
+    assert urls == ["https://live.example/double-quoted"]
+    assert concatenated == []
+
+
+def test_extract_urls_keeps_urls_in_multiline_single_quoted_yaml_scalar(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "example.yml"
+    file_path.write_text(
+        "\n".join(
+            [
+                "note: 'first line",
+                "  https://live.example/single-quoted",
+                "  it''s still content # not a comment'",
+                "field: value # https://commented.example/trailing",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    urls, concatenated = extract_urls_from_file(
+        file_path, LinkifyIt(options={"fuzzy_link": False})
+    )
+
+    assert urls == ["https://live.example/single-quoted"]
+    assert concatenated == []
+
+
 def test_extract_urls_keeps_markdown_heading_urls_in_yaml_block_scalar(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_check_questions_urls.py
+++ b/tests/test_check_questions_urls.py
@@ -3,7 +3,11 @@ from pathlib import Path
 from linkify_it import LinkifyIt
 
 import dayamlchecker.check_questions_urls as check_questions_urls
-from dayamlchecker.check_questions_urls import check_urls, extract_text_from_pdf, extract_urls_from_file
+from dayamlchecker.check_questions_urls import (
+    check_urls,
+    extract_text_from_pdf,
+    extract_urls_from_file,
+)
 
 
 def test_extract_urls_skips_python_comment_urls(tmp_path: Path) -> None:

--- a/tests/test_check_questions_urls.py
+++ b/tests/test_check_questions_urls.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+
+from linkify_it import LinkifyIt
+
+from dayamlchecker.check_questions_urls import extract_urls_from_file
+
+
+def test_extract_urls_skips_python_comment_urls(tmp_path: Path) -> None:
+    file_path = tmp_path / "example.py"
+    file_path.write_text(
+        "\n".join(
+            [
+                "# https://commented.example/full-line",
+                'live = "https://live.example/value"',
+                "value = 1  # https://commented.example/trailing",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    urls, concatenated = extract_urls_from_file(
+        file_path, LinkifyIt(options={"fuzzy_link": False})
+    )
+
+    assert urls == ["https://live.example/value"]
+    assert concatenated == []
+
+
+def test_extract_urls_skips_yaml_comment_urls(tmp_path: Path) -> None:
+    file_path = tmp_path / "example.yml"
+    file_path.write_text(
+        "\n".join(
+            [
+                "# https://commented.example/full-line",
+                'live: "https://live.example/value"',
+                "note: keep # not-a-comment-inside-value",
+                "value: yes # https://commented.example/trailing",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    urls, concatenated = extract_urls_from_file(
+        file_path, LinkifyIt(options={"fuzzy_link": False})
+    )
+
+    assert urls == ["https://live.example/value"]
+    assert concatenated == []
+
+
+def test_extract_urls_keeps_markdown_heading_urls_in_yaml_block_scalar(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "example.yml"
+    file_path.write_text(
+        "\n".join(
+            [
+                "question: |",
+                "  # Heading",
+                "  Visit https://live.example/question",
+                "subquestion: |",
+                "  ## Subheading https://live.example/subquestion",
+                "note: |",
+                "  ### Note https://live.example/note",
+                "field: value # https://commented.example/trailing",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    urls, concatenated = extract_urls_from_file(
+        file_path, LinkifyIt(options={"fuzzy_link": False})
+    )
+
+    assert urls == [
+        "https://live.example/question",
+        "https://live.example/subquestion",
+        "https://live.example/note",
+    ]
+    assert concatenated == []
+
+
+def test_extract_urls_keeps_markdown_heading_urls_in_template_and_attachment_blocks(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "example.yml"
+    file_path.write_text(
+        "\n".join(
+            [
+                "template: review_email",
+                "subject: |",
+                "  # Subject https://live.example/template-subject",
+                "content: |",
+                "  ## Content https://live.example/template-content",
+                "---",
+                "attachment:",
+                "  name: review_letter",
+                "  content: |",
+                "    ### Attachment https://live.example/attachment-content",
+                "  filename: review.pdf",
+                "metadata: yes # https://commented.example/trailing",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    urls, concatenated = extract_urls_from_file(
+        file_path, LinkifyIt(options={"fuzzy_link": False})
+    )
+
+    assert urls == [
+        "https://live.example/template-subject",
+        "https://live.example/template-content",
+        "https://live.example/attachment-content",
+    ]
+    assert concatenated == []
+
+
+def test_extract_urls_skips_python_comment_urls_in_code_block_scalar(
+    tmp_path: Path,
+) -> None:
+    file_path = tmp_path / "example.yml"
+    file_path.write_text(
+        "\n".join(
+            [
+                "code: |",
+                "  # https://commented.example/full-line",
+                '  live = "https://live.example/value"',
+                "  value = 1  # https://commented.example/trailing",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    urls, concatenated = extract_urls_from_file(
+        file_path, LinkifyIt(options={"fuzzy_link": False})
+    )
+
+    assert urls == ["https://live.example/value"]
+    assert concatenated == []

--- a/tests/test_check_questions_urls.py
+++ b/tests/test_check_questions_urls.py
@@ -1,6 +1,8 @@
 from pathlib import Path
+from typing import cast
 
-from linkify_it import LinkifyIt
+from linkify_it import LinkifyIt  # type: ignore[attr-defined,import-untyped]
+from requests import Session
 
 import dayamlchecker.check_questions_urls as check_questions_urls
 from dayamlchecker.check_questions_urls import (
@@ -268,7 +270,7 @@ def test_check_urls_tries_pdf_repair_candidates_after_dead_link() -> None:
 
     session = FakeSession()
     broken, unreachable = check_urls(
-        session,
+        cast(Session, session),
         ["https://www.courts.michigan.gov/49752a/siteassets/forms/scao-"],
         timeout=10,
         repair_candidates={


### PR DESCRIPTION
Fix #25 Fix #24 

Note:

1) We check for both Python and YAML comments and ignore URLs in those contexts, while trying our best to still warn about links inside a Markdown heading level (which also uses `#`). Should make it easier to include an example/demo URL in a comment. But note: you could always have used example.com as the domain name, which is probably better if it's not a real link
2) when a PDF lacks the /link annotation, we try to use the same heuristics (just guessing here though as I don't have access to Acrobat's code to see how they detect links without an annotation) to detect a line break in the middle of a URL. We only do this for PDFs because they can have hardcoded `\n`. Won't have same problem in other contexts. (We only try the joined URL if the version before linebreak is a 404)