### PR TITLE
Raise a validation error when a block has only id + comment, just like Docassemble does

### DIFF
--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -1508,7 +1508,13 @@ def find_errors_from_string(
                 )
 
         any_types = [block for block in types_of_blocks.keys() if block in doc]
-        if len(any_types) == 0:
+non_meta_keys = {
+    key for key in doc.keys() if isinstance(key, str) and key != "__line__"
+}
+any_types = [block for block in types_of_blocks.keys() if block in non_meta_keys]
+if len(non_meta_keys) == 1 and 'comment' in non_meta_keys:
+    pass # allow attribute comment blocks
+elif len(any_types) == 0:
             all_errors.append(
                 YAMLError(
                     err_str=f"No possible types found: {doc}",

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -1507,21 +1507,27 @@ def find_errors_from_string(
                     )
                 )
 
-        any_types = [block for block in types_of_blocks.keys() if block in doc]
-non_meta_keys = {
-    key for key in doc.keys() if isinstance(key, str) and key != "__line__"
-}
-any_types = [block for block in types_of_blocks.keys() if block in non_meta_keys]
-if len(non_meta_keys) == 1 and 'comment' in non_meta_keys:
-    pass # allow attribute comment blocks
-elif len(any_types) == 0:
-            all_errors.append(
-                YAMLError(
-                    err_str=f"No possible types found: {doc}",
-                    line_number=line_number,
-                    file_name=input_file,
+        non_meta_keys = {
+            key for key in doc.keys() if isinstance(key, str) and key != "__line__"
+        }
+        if non_meta_keys == {"comment"}:
+            # docassemble ignores comment-only blocks, but once another attribute
+            # is present the block still needs a real question/directive type.
+            pass
+        else:
+            any_types = [
+                block
+                for block in types_of_blocks.keys()
+                if block in non_meta_keys and block != "comment"
+            ]
+            if len(any_types) == 0:
+                all_errors.append(
+                    YAMLError(
+                        err_str=f"No possible types found: {doc}",
+                        line_number=line_number,
+                        file_name=input_file,
+                    )
                 )
-            )
         posb_types = [block for block in exclusive_keys if block in doc]
         if len(posb_types) > 1:
             if len(posb_types) == 2 and posb_types[1] in (
@@ -1537,19 +1543,6 @@ elif len(any_types) == 0:
                     )
                 )
 
-        non_meta_keys = {
-            key for key in doc.keys() if isinstance(key, str) and key != "__line__"
-        }
-        if non_meta_keys == {"comment", "id"}:
-            all_errors.append(
-                YAMLError(
-                    err_str=(
-                        "Comment-only block cannot also define id; docassemble errors on blocks that only contain comment and id"
-                    ),
-                    line_number=line_number,
-                    file_name=input_file,
-                )
-            )
         weird_keys = []
         for attr in doc.keys():
             if attr == "__line__":

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -1530,6 +1530,20 @@ def find_errors_from_string(
                         file_name=input_file,
                     )
                 )
+
+        non_meta_keys = {
+            key for key in doc.keys() if isinstance(key, str) and key != "__line__"
+        }
+        if non_meta_keys == {"comment", "id"}:
+            all_errors.append(
+                YAMLError(
+                    err_str=(
+                        "Comment-only block cannot also define id; docassemble errors on blocks that only contain comment and id"
+                    ),
+                    line_number=line_number,
+                    file_name=input_file,
+                )
+            )
         weird_keys = []
         for attr in doc.keys():
             if attr == "__line__":

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -258,11 +258,30 @@ comment: |
 """
         errs = find_errors_from_string(yaml_content, input_file="<string_invalid>")
         self.assertTrue(
-            any(
-                "comment-only block cannot also define id" in e.err_str.lower()
-                for e in errs
-            ),
-            f"Expected comment+id validation error, got: {errs}",
+            any("no possible types found" in e.err_str.lower() for e in errs),
+            f"Expected comment+id no-type validation error, got: {errs}",
+        )
+
+    def test_comment_and_non_type_attribute_block_invalid(self):
+        yaml_content = """comment: |
+  Notes for maintainers only
+ga id: comment_block
+"""
+        errs = find_errors_from_string(yaml_content, input_file="<string_invalid>")
+        self.assertTrue(
+            any("no possible types found" in e.err_str.lower() for e in errs),
+            f"Expected comment+ga id no-type validation error, got: {errs}",
+        )
+
+    def test_comment_and_modifier_without_type_block_invalid(self):
+        yaml_content = """comment: |
+  Notes for maintainers only
+mandatory: True
+"""
+        errs = find_errors_from_string(yaml_content, input_file="<string_invalid>")
+        self.assertTrue(
+            any("no possible types found" in e.err_str.lower() for e in errs),
+            f"Expected comment+mandatory no-type validation error, got: {errs}",
         )
 
     def test_accessibility_mode_still_reports_yaml_parse_errors(self):

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -242,6 +242,29 @@ subquestion: |
             f"Expected structural errors for non-Docassemble YAML in accessibility mode, got: {errs}",
         )
 
+    def test_comment_only_block_valid(self):
+        yaml_content = """comment: |
+  Notes for maintainers only
+"""
+        errs = find_errors_from_string(yaml_content, input_file="<string_valid>")
+        self.assertEqual(
+            len(errs), 0, f"Expected no errors for comment-only block, got: {errs}"
+        )
+
+    def test_comment_and_id_only_block_invalid(self):
+        yaml_content = """id: comment_block
+comment: |
+  Notes for maintainers only
+"""
+        errs = find_errors_from_string(yaml_content, input_file="<string_invalid>")
+        self.assertTrue(
+            any(
+                "comment-only block cannot also define id" in e.err_str.lower()
+                for e in errs
+            ),
+            f"Expected comment+id validation error, got: {errs}",
+        )
+
     def test_accessibility_mode_still_reports_yaml_parse_errors(self):
         yaml_content = """question: |
   Bad yaml


### PR DESCRIPTION
I've been running into this when editing the new Flask endpoint Weaver, it should be caught by static analysis

Raised in a comment in #1 but this doesn't address specific issue with `include` block.