### PR TITLE
Check that fields with MakoText values are valid

### DIFF
--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -448,6 +448,8 @@ class DAFields:
         "__line__",
     }
 
+    mako_keys = {"default", "hint", "label", "note"}
+
     js_modifier_keys = ("js show if", "js hide if", "js enable if", "js disable if")
     py_modifier_keys = ("show if", "hide if", "enable if", "disable if")
 
@@ -607,18 +609,26 @@ class DAFields:
                 continue
 
             for field_key in field_item:
-                if (
-                    isinstance(field_key, str)
-                    and field_key != "__line__"
-                    and field_key not in self.modifier_keys
-                    and field_key.lower() in self.modifier_keys
-                ):
-                    self.errors.append(
-                        (
-                            f'Invalid field key "{field_key}". docassemble field modifier keys are case-sensitive; use "{field_key.lower()}"',
-                            self._line_for(field_item),
+                if isinstance(field_key, str) and field_key != "__line__":
+                    if (
+                        field_key not in self.modifier_keys
+                        and field_key.lower() in self.modifier_keys
+                    ):
+                        self.errors.append(
+                            (
+                                f'Invalid field key "{field_key}". docassemble field modifier keys are case-sensitive; use "{field_key.lower()}"',
+                                self._line_for(field_item),
+                            )
                         )
-                    )
+                    if field_key in self.mako_keys:
+                        the_mako = MakoText(str(field_item[field_key]))
+                        for err in the_mako.errors:
+                            self.errors.append(
+                                (
+                                    f"{field_key} value has {err[0]}",
+                                    self._line_for(field_item, err[1]),
+                                )
+                            )
 
             for js_key in self.js_modifier_keys:
                 if js_key in field_item:

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -1469,6 +1469,30 @@ continue button field: interrogatory_questions
             f"Expected no fields-shape errors, got: {field_errors}",
         )
 
+    def test_fields_mako_templates_valid(self):
+        """Error: fields with mako in them are checked."""
+        valid = """
+question: |
+  Interrogatories
+fields:
+  - "Ints fields": ints_fields
+    default: |
+      ${ 1 + 3
+         + 5}
+continue button field: interrogatory_questions
+"""
+        errs = find_errors_from_string(valid, input_file="<string_valid>")
+        field_errors = [
+            e
+            for e in errs
+            if "default value has (indentationerror)" in e.err_str.lower()
+        ]
+        self.assertEqual(
+            len(field_errors),
+            1,
+            f"Expected one mako field errors, got: {field_errors}",
+        )
+
     def test_interview_order_reference_without_matching_guard_errors(self):
         """Error when interview-order style code references a conditionally shown field without guard"""
         invalid = """


### PR DESCRIPTION
To make sure we can find issues like https://github.com/SuffolkLITLab/docassemble-ALDashboard/pull/221.

Checks the following field attributes to make sure they are valid MakoTemplates:

* default
* describe
* label
* note