### PR TITLE
Implement PythonBool validator for mandatory, initial, scan for variables

### DIFF
--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -203,7 +203,22 @@ class PythonBool:
 
     def __init__(self, x):
         self.errors = []
-        pass
+        if isinstance(x, bool):
+            return
+        #number like 10 or 0 - not valid, even though Python treats them as truthy/falsy
+        if isinstance(x, (int, float)):
+            self.errors = [(f"expected True, False, or a Python expression, got number: {x}", 1)]
+            return
+        #must be a string at this point
+        if not isinstance(x, str):
+            self.errors = [(f"expected True, False, or a Python expression, got: {type(x).__name__}", 1)]
+            return
+        #try parsing it as a Python expression - covers things like "user_age > 18"
+        try:
+            ast.parse(x)
+        except SyntaxError as ex:
+            msg = ex.msg or str(ex)
+            self.errors = [(f"expected True, False, or a valid Python expression, got: {x!r} (Python syntax error: {msg})", 1)]
 
 
 class JavascriptText:
@@ -751,10 +766,10 @@ big_dict: dict[str, dict[str, Any]] = {
     "default language": {},
     "default validation messages": {},
     "machine learning storage": {},
-    "scan for variables": {},
+    "scan for variables": {"type": PythonBool},
     "if": {},
     "sets": {},
-    "initial": {},
+    "initial": {"type": PythonBool},
     "event": {},
     "comment": {},
     "generic object": {"type": DAPythonVar},

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -205,20 +205,32 @@ class PythonBool:
         self.errors = []
         if isinstance(x, bool):
             return
-        #number like 10 or 0 - not valid, even though Python treats them as truthy/falsy
+        # number like 10 or 0 - not valid, even though Python treats them as truthy/falsy
         if isinstance(x, (int, float)):
-            self.errors = [(f"expected True, False, or a Python expression, got number: {x}", 1)]
+            self.errors = [
+                (f"expected True, False, or a Python expression, got number: {x}", 1)
+            ]
             return
-        #must be a string at this point
+        # must be a string at this point
         if not isinstance(x, str):
-            self.errors = [(f"expected True, False, or a Python expression, got: {type(x).__name__}", 1)]
+            self.errors = [
+                (
+                    f"expected True, False, or a Python expression, got: {type(x).__name__}",
+                    1,
+                )
+            ]
             return
-        #try parsing it as a Python expression - covers things like "user_age > 18"
+        # try parsing it as a Python expression - covers things like "user_age > 18"
         try:
             ast.parse(x)
         except SyntaxError as ex:
             msg = ex.msg or str(ex)
-            self.errors = [(f"expected True, False, or a valid Python expression, got: {x!r} (Python syntax error: {msg})", 1)]
+            self.errors = [
+                (
+                    f"expected True, False, or a valid Python expression, got: {x!r} (Python syntax error: {msg})",
+                    1,
+                )
+            ]
 
 
 class JavascriptText:

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -778,7 +778,7 @@ big_dict: dict[str, dict[str, Any]] = {
     "default language": {},
     "default validation messages": {},
     "machine learning storage": {},
-    "scan for variables": {"type": PythonBool},
+    "scan for variables": {},
     "if": {},
     "sets": {},
     "initial": {"type": PythonBool},

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -1815,19 +1815,6 @@ code: |
             f"Expected initial number error, got: {errs}",
         )
 
-    def test_scan_for_variables_invalid_string_errors(self):
-        """Error: scan for variables with invalid string should be flagged"""
-        invalid = """
-scan for variables: yes please
-code: |
-  x = 1
-"""
-        errs = find_errors_from_string(invalid, input_file="<string_invalid>")
-        self.assertTrue(
-            any("expected True, False" in e.err_str for e in errs),
-            f"Expected scan for variables error, got: {errs}",
-        )
-
     def test_mandatory_null_errors(self):
         """Error: mandatory: null should be flagged"""
         invalid = """

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -1732,6 +1732,116 @@ fields:
             f"Did not expect nesting warning, got: {errs}",
         )
 
+    def test_mandatory_number_errors(self):
+        """Error: mandatory with a number should be flagged"""
+        invalid = """
+mandatory: 10
+question: |
+  Hello
+field: user_name
+"""
+        errs = find_errors_from_string(invalid, input_file="<string_invalid>")
+        self.assertTrue(
+            any("got number: 10" in e.err_str for e in errs),
+            f"Expected mandatory number error, got: {errs}",
+        )
+
+    def test_mandatory_bool_true_valid(self):
+        """Valid: mandatory: True should pass"""
+        valid = """
+mandatory: True
+question: |
+  Hello
+field: user_name
+"""
+        errs = find_errors_from_string(valid, input_file="<string_valid>")
+        self.assertFalse(
+            any("expected True, False" in e.err_str for e in errs),
+            f"Did not expect mandatory error for True, got: {errs}",
+        )
+
+    def test_mandatory_bool_false_valid(self):
+        """Valid: mandatory: False should pass"""
+        valid = """
+mandatory: False
+question: |
+  Hello
+field: user_name
+"""
+        errs = find_errors_from_string(valid, input_file="<string_valid>")
+        self.assertFalse(
+            any("expected True, False" in e.err_str for e in errs),
+            f"Did not expect mandatory error for False, got: {errs}",
+        )
+
+    def test_mandatory_python_expression_valid(self):
+        """Valid: mandatory with a Python expression should pass"""
+        valid = """
+mandatory: user_age > 18
+question: |
+  Hello
+field: user_name
+"""
+        errs = find_errors_from_string(valid, input_file="<string_valid>")
+        self.assertFalse(
+            any("expected True, False" in e.err_str for e in errs),
+            f"Did not expect mandatory error for Python expression, got: {errs}",
+        )
+
+    def test_mandatory_invalid_string_errors(self):
+        """Error: mandatory with a non-Python string should be flagged"""
+        invalid = """
+mandatory: yes please
+question: |
+  Hello
+field: user_name
+"""
+        errs = find_errors_from_string(invalid, input_file="<string_invalid>")
+        self.assertTrue(
+            any("expected True, False" in e.err_str for e in errs),
+            f"Expected mandatory invalid string error, got: {errs}",
+        )
+
+    def test_initial_number_errors(self):
+        """Error: initial with a number should be flagged"""
+        invalid = """
+initial: 10
+code: |
+  x = 1
+"""
+        errs = find_errors_from_string(invalid, input_file="<string_invalid>")
+        self.assertTrue(
+            any("got number: 10" in e.err_str for e in errs),
+            f"Expected initial number error, got: {errs}",
+        )
+
+    def test_scan_for_variables_invalid_string_errors(self):
+        """Error: scan for variables with invalid string should be flagged"""
+        invalid = """
+scan for variables: yes please
+code: |
+  x = 1
+"""
+        errs = find_errors_from_string(invalid, input_file="<string_invalid>")
+        self.assertTrue(
+            any("expected True, False" in e.err_str for e in errs),
+            f"Expected scan for variables error, got: {errs}",
+        )
+
+    def test_mandatory_null_errors(self):
+        """Error: mandatory: null should be flagged"""
+        invalid = """
+mandatory: null
+question: |
+  Hello
+field: user_name
+"""
+        errs = find_errors_from_string(invalid, input_file="<string_invalid>")
+        self.assertTrue(
+            any("expected True, False" in e.err_str for e in errs),
+            f"Expected mandatory null error, got: {errs}",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`PythonBool` was a stub class with no validation. This implements it to catch cases where attributes like `mandatory`, `initial`, and `scan for variables` are set to invalid values like numbers or non-Python strings. Added tests covering valid and invalid cases for all three attributes.

Valid values: `True`, `False`, or a Python expression like `user_age > 18`
Invalid values: numbers like `10`, strings like `"yes please"`, `null`

