### PR TITLE
Refactor findings into a shared message catalog

### DIFF
--- a/src/dayamlchecker/accessibility.py
+++ b/src/dayamlchecker/accessibility.py
@@ -595,7 +595,8 @@ def _extract_field_variable(field: dict[str, Any]) -> str:
     if (
         isinstance(no_label_value, str)
         and no_label_value.strip()
-        and no_label_value.strip().lower() not in {"true", "false", "yes", "no", "1", "0", "on", "off"}
+        and no_label_value.strip().lower()
+        not in {"true", "false", "yes", "no", "1", "0", "on", "off"}
     ):
         return no_label_value.strip()
     for key, value in field.items():

--- a/src/dayamlchecker/accessibility.py
+++ b/src/dayamlchecker/accessibility.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 import re
 from typing import Any, Optional
+from dayamlchecker.messages import Finding, FindingDraft, MessageId, draft
 
 TEXT_SECTION_KEYS = ("question", "subquestion", "under", "help", "note", "html")
 FIELD_NON_LABEL_KEYS = {
@@ -41,11 +42,9 @@ GENERIC_LINK_TEXT = {
 }
 
 
-@dataclass(frozen=True)
-class AccessibilityFinding:
-    rule_id: str
-    message: str
-    line_number: int
+@dataclass(frozen=True, slots=True)
+class AccessibilityFinding(Finding):
+    pass
 
 
 @dataclass(frozen=True)
@@ -118,7 +117,7 @@ def find_accessibility_findings(
     options: Optional[AccessibilityLintOptions] = None,
 ) -> list[AccessibilityFinding]:
     options = options or AccessibilityLintOptions()
-    findings: list[AccessibilityFinding] = []
+    findings: list[FindingDraft] = []
     findings.extend(_check_multifield_no_label_usage(doc, document_start_line))
     findings.extend(
         _check_combobox_usage(doc, source_code, document_start_line, options=options)
@@ -151,11 +150,17 @@ def find_accessibility_findings(
     unique_findings: list[AccessibilityFinding] = []
     seen: set[tuple[str, str, int]] = set()
     for finding in findings:
-        key = (finding.rule_id, finding.message, finding.line_number)
+        rendered = AccessibilityFinding(
+            message_id=finding.message_id,
+            file_name=input_file,
+            line_number=finding.line_number,
+            context=finding.context,
+        )
+        key = (rendered.code, rendered.message, rendered.line_number or 0)
         if key in seen:
             continue
         seen.add(key)
-        unique_findings.append(finding)
+        unique_findings.append(rendered)
     return unique_findings
 
 
@@ -165,11 +170,11 @@ def _check_combobox_usage(
     document_start_line: int,
     *,
     options: AccessibilityLintOptions,
-) -> list[AccessibilityFinding]:
+) -> list[FindingDraft]:
     if not options.errors_on_widget("combobox"):
         return []
 
-    findings: list[AccessibilityFinding] = []
+    findings: list[FindingDraft] = []
     top_level_combobox = doc.get("combobox")
     if top_level_combobox is not None:
         line_number = _absolute_line_number(
@@ -179,10 +184,10 @@ def _check_combobox_usage(
             "combobox:",
         )
         findings.append(
-            AccessibilityFinding(
-                rule_id="combobox-not-accessible",
-                message="Accessibility: screen uses `combobox`, which is not allowed for accessibility reasons",
+            draft(
+                MessageId.ACCESSIBILITY_COMBOBOX_NOT_ACCESSIBLE,
                 line_number=line_number,
+                subject="screen",
             )
         )
 
@@ -196,15 +201,12 @@ def _check_combobox_usage(
             or "<unknown field>"
         )
         findings.append(
-            AccessibilityFinding(
-                rule_id="combobox-not-accessible",
-                message=(
-                    "Accessibility: field uses `datatype: combobox`, which is not allowed for accessibility reasons: "
-                    f"{field_label}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_COMBOBOX_NOT_ACCESSIBLE,
                 line_number=document_start_line
                 + field.get("__line__", doc.get("__line__", 1))
                 - 1,
+                subject=f'field "{field_label}"',
             )
         )
 
@@ -213,12 +215,12 @@ def _check_combobox_usage(
 
 def _check_multifield_no_label_usage(
     doc: dict[str, Any], document_start_line: int
-) -> list[AccessibilityFinding]:
+) -> list[FindingDraft]:
     fields = _iter_fields(doc)
     if len(fields) <= 1:
         return []
 
-    findings: list[AccessibilityFinding] = []
+    findings: list[FindingDraft] = []
     for field in fields:
         if "code" in field:
             continue
@@ -237,13 +239,11 @@ def _check_multifield_no_label_usage(
 
         field_name = _extract_field_variable(field) or "<unknown field>"
         findings.append(
-            AccessibilityFinding(
-                rule_id="no-label-on-multi-field-screen",
-                message=(
-                    "Accessibility: `no label` or empty/missing field label is only allowed on single-field screens; "
-                    f"screen has {len(fields)} fields: {field_name}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_NO_LABEL_MULTI_FIELD,
                 line_number=field_line,
+                field_count=len(fields),
+                field_name=field_name,
             )
         )
     return findings
@@ -251,7 +251,7 @@ def _check_multifield_no_label_usage(
 
 def _check_tagged_pdf_for_docx(
     doc: dict[str, Any], source_code: str, document_start_line: int
-) -> list[AccessibilityFinding]:
+) -> list[FindingDraft]:
     attachments = doc.get("attachments")
     if isinstance(attachments, dict):
         attachments = [attachments]
@@ -263,7 +263,7 @@ def _check_tagged_pdf_for_docx(
     if isinstance(features, dict):
         feature_tagged_pdf = _is_truthy(features.get("tagged pdf"))
 
-    findings: list[AccessibilityFinding] = []
+    findings: list[FindingDraft] = []
     for attachment in attachments:
         if not isinstance(attachment, dict):
             continue
@@ -282,12 +282,8 @@ def _check_tagged_pdf_for_docx(
             "attachments:",
         )
         findings.append(
-            AccessibilityFinding(
-                rule_id="tagged-pdf-not-enabled",
-                message=(
-                    "Info: Accessibility: DOCX attachment detected without `tagged pdf: True`; "
-                    "set it on `features` or the attachment to improve generated PDF accessibility"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_TAGGED_PDF_NOT_ENABLED,
                 line_number=line_number,
             )
         )
@@ -300,7 +296,7 @@ def _check_theme_css_contrast(
     document_start_line: int,
     *,
     input_file: Optional[str] = None,
-) -> list[AccessibilityFinding]:
+) -> list[FindingDraft]:
     features = doc.get("features")
     if not isinstance(features, dict):
         return []
@@ -323,7 +319,7 @@ def _check_theme_css_contrast(
         return []
 
     selector_props, variables = _parse_css_rules(css_content)
-    findings: list[AccessibilityFinding] = []
+    findings: list[FindingDraft] = []
     for component, patterns in _COMPONENT_SELECTORS.items():
         pair = _best_component_color_pair(selector_props, variables, patterns)
         if pair is None:
@@ -333,13 +329,12 @@ def _check_theme_css_contrast(
         if ratio >= WCAG_MIN_CONTRAST_RATIO:
             continue
         findings.append(
-            AccessibilityFinding(
-                rule_id="theme-contrast-too-low",
-                message=(
-                    "Accessibility: bootstrap theme CSS has low contrast for "
-                    f"{component} (ratio {ratio:.2f}:1, expected at least {WCAG_MIN_CONTRAST_RATIO:.1f}:1)"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_THEME_CONTRAST_TOO_LOW,
                 line_number=line_number,
+                component=component,
+                ratio=ratio,
+                minimum_ratio=WCAG_MIN_CONTRAST_RATIO,
             )
         )
     return findings
@@ -375,24 +370,24 @@ def _iter_text_sections(doc: dict[str, Any], source_code: str) -> list[TextSecti
 
 def _check_missing_alt_text(
     section: TextSection, source_code: str, document_start_line: int
-) -> list[AccessibilityFinding]:
-    findings: list[AccessibilityFinding] = []
+) -> list[FindingDraft]:
+    findings: list[FindingDraft] = []
     for alt_text, image_target in _MARKDOWN_IMAGE_RE.findall(section.value):
         if alt_text.strip():
             continue
         snippet = f"![{alt_text}]({image_target})"
         findings.append(
-            AccessibilityFinding(
-                rule_id="image-missing-alt-text",
-                message=(
-                    f"Accessibility: markdown image in {section.location} is missing alt text: {snippet}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_IMAGE_MISSING_ALT_TEXT,
                 line_number=_absolute_line_number(
                     source_code,
                     document_start_line,
                     section.key_line,
                     snippet,
                 ),
+                image_kind="markdown image",
+                section_location=section.location,
+                snippet=snippet,
             )
         )
 
@@ -402,17 +397,17 @@ def _check_missing_alt_text(
             continue
         snippet = file_tag_match.group(0)
         findings.append(
-            AccessibilityFinding(
-                rule_id="image-missing-alt-text",
-                message=(
-                    f"Accessibility: [FILE ...] image in {section.location} is missing alt text: {snippet}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_IMAGE_MISSING_ALT_TEXT,
                 line_number=_absolute_line_number(
                     source_code,
                     document_start_line,
                     section.key_line,
                     f"[FILE {file_target}",
                 ),
+                image_kind="[FILE ...] image",
+                section_location=section.location,
+                snippet=snippet,
             )
         )
 
@@ -421,17 +416,17 @@ def _check_missing_alt_text(
         if alt_match and alt_match.group(2).strip():
             continue
         findings.append(
-            AccessibilityFinding(
-                rule_id="image-missing-alt-text",
-                message=(
-                    f"Accessibility: HTML image in {section.location} is missing alt text: {img_tag.strip()}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_IMAGE_MISSING_ALT_TEXT,
                 line_number=_absolute_line_number(
                     source_code,
                     document_start_line,
                     section.key_line,
                     img_tag.strip(),
                 ),
+                image_kind="HTML image",
+                section_location=section.location,
+                snippet=img_tag.strip(),
             )
         )
     return findings
@@ -439,8 +434,8 @@ def _check_missing_alt_text(
 
 def _check_markdown_heading_order(
     section: TextSection, source_code: str, document_start_line: int
-) -> list[AccessibilityFinding]:
-    findings: list[AccessibilityFinding] = []
+) -> list[FindingDraft]:
+    findings: list[FindingDraft] = []
     matches = list(_MARKDOWN_HEADING_RE.finditer(section.value))
     for index in range(1, len(matches)):
         previous_level = len(matches[index - 1].group(1))
@@ -449,18 +444,18 @@ def _check_markdown_heading_order(
             continue
         line_text = matches[index].group(0).strip()
         findings.append(
-            AccessibilityFinding(
-                rule_id="markdown-heading-level-skip",
-                message=(
-                    "Accessibility: markdown heading levels skip "
-                    f"from H{previous_level} to H{current_level} in {section.location}: {line_text}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_MARKDOWN_HEADING_LEVEL_SKIP,
                 line_number=_absolute_line_number(
                     source_code,
                     document_start_line,
                     section.key_line,
                     line_text,
                 ),
+                previous_level=previous_level,
+                current_level=current_level,
+                section_location=section.location,
+                snippet=line_text,
             )
         )
         break
@@ -469,8 +464,8 @@ def _check_markdown_heading_order(
 
 def _check_html_heading_order(
     section: TextSection, source_code: str, document_start_line: int
-) -> list[AccessibilityFinding]:
-    findings: list[AccessibilityFinding] = []
+) -> list[FindingDraft]:
+    findings: list[FindingDraft] = []
     matches = list(_HTML_HEADING_RE.finditer(section.value))
     for index in range(1, len(matches)):
         previous_level = int(matches[index - 1].group(1))
@@ -479,18 +474,18 @@ def _check_html_heading_order(
             continue
         snippet = re.sub(r"\s+", " ", matches[index].group(0)).strip()
         findings.append(
-            AccessibilityFinding(
-                rule_id="html-heading-level-skip",
-                message=(
-                    "Accessibility: HTML heading levels skip "
-                    f"from H{previous_level} to H{current_level} in {section.location}: {snippet}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_HTML_HEADING_LEVEL_SKIP,
                 line_number=_absolute_line_number(
                     source_code,
                     document_start_line,
                     section.key_line,
                     snippet,
                 ),
+                previous_level=previous_level,
+                current_level=current_level,
+                section_location=section.location,
+                snippet=snippet,
             )
         )
         break
@@ -499,8 +494,8 @@ def _check_html_heading_order(
 
 def _check_empty_link_text(
     section: TextSection, source_code: str, document_start_line: int
-) -> list[AccessibilityFinding]:
-    findings: list[AccessibilityFinding] = []
+) -> list[FindingDraft]:
+    findings: list[FindingDraft] = []
     for link in _extract_links_from_text(section.value):
         visible_text = _normalize_human_text(link["text"])
         if visible_text:
@@ -510,17 +505,16 @@ def _check_empty_link_text(
         ):
             continue
         findings.append(
-            AccessibilityFinding(
-                rule_id="empty-link-text",
-                message=(
-                    f"Accessibility: link in {section.location} has no accessible text: {link['snippet']}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_EMPTY_LINK_TEXT,
                 line_number=_absolute_line_number(
                     source_code,
                     document_start_line,
                     section.key_line,
                     link["snippet"],
                 ),
+                section_location=section.location,
+                snippet=link["snippet"],
             )
         )
     return findings
@@ -528,24 +522,23 @@ def _check_empty_link_text(
 
 def _check_non_descriptive_link_text(
     section: TextSection, source_code: str, document_start_line: int
-) -> list[AccessibilityFinding]:
-    findings: list[AccessibilityFinding] = []
+) -> list[FindingDraft]:
+    findings: list[FindingDraft] = []
     for link in _extract_links_from_text(section.value):
         normalized = _normalize_human_text(link["text"])
         if not normalized or normalized not in GENERIC_LINK_TEXT:
             continue
         findings.append(
-            AccessibilityFinding(
-                rule_id="non-descriptive-link-text",
-                message=(
-                    f"Accessibility: link text in {section.location} is too generic: {link['text'].strip() or link['snippet']}"
-                ),
+            draft(
+                MessageId.ACCESSIBILITY_NON_DESCRIPTIVE_LINK_TEXT,
                 line_number=_absolute_line_number(
                     source_code,
                     document_start_line,
                     section.key_line,
                     link["snippet"],
                 ),
+                section_location=section.location,
+                text=link["text"].strip() or link["snippet"],
             )
         )
     return findings

--- a/src/dayamlchecker/accessibility.py
+++ b/src/dayamlchecker/accessibility.py
@@ -591,6 +591,13 @@ def _extract_field_variable(field: dict[str, Any]) -> str:
     explicit = str(field.get("field") or "").strip()
     if explicit:
         return explicit
+    no_label_value = field.get("no label")
+    if (
+        isinstance(no_label_value, str)
+        and no_label_value.strip()
+        and no_label_value.strip().lower() not in {"true", "false", "yes", "no", "1", "0", "on", "off"}
+    ):
+        return no_label_value.strip()
     for key, value in field.items():
         if key in FIELD_NON_LABEL_KEYS:
             continue

--- a/src/dayamlchecker/check_questions_urls.py
+++ b/src/dayamlchecker/check_questions_urls.py
@@ -1019,9 +1019,7 @@ def print_url_check_report(result: URLCheckResult) -> None:
                 ]
                 if not bucket:
                     continue
-                print(
-                    title_labels[category].format(source=_source_label(source_kind))
-                )
+                print(title_labels[category].format(source=_source_label(source_kind)))
                 for issue in bucket:
                     print(f"- [{issue.code}] {issue.message}")
 

--- a/src/dayamlchecker/check_questions_urls.py
+++ b/src/dayamlchecker/check_questions_urls.py
@@ -16,6 +16,7 @@ from io import StringIO
 from typing import Literal
 from urllib.parse import urlparse
 
+from dayamlchecker.messages import Finding, MessageId
 import requests
 from docx2python import docx2python
 from linkify_it import LinkifyIt  # type: ignore[attr-defined,import-untyped]
@@ -33,14 +34,42 @@ SourceKind = Literal["yaml", "template"]
 IssueCategory = Literal["broken", "concatenated", "unreachable"]
 
 
-@dataclass(frozen=True)
-class URLIssue:
-    severity: ReportSeverity
+@dataclass(frozen=True, kw_only=True)
+class URLIssue(Finding):
     category: IssueCategory
     source_kind: SourceKind
     url: str
     sources: tuple[str, ...]
     status_code: int | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        severity: ReportSeverity,
+        category: IssueCategory,
+        source_kind: SourceKind,
+        url: str,
+        sources: tuple[str, ...],
+        status_code: int | None = None,
+    ) -> "URLIssue":
+        source_label = _source_label(source_kind)
+        return cls(
+            message_id=_url_message_id(severity=severity, category=category),
+            file_name=sources[0] if len(sources) == 1 else None,
+            line_number=None,
+            context={
+                "source_label": source_label,
+                "url": url,
+                "sources": ", ".join(sources),
+                "status_code": status_code,
+            },
+            category=category,
+            source_kind=source_kind,
+            url=url,
+            sources=sources,
+            status_code=status_code,
+        )
 
 
 @dataclass(frozen=True)
@@ -68,6 +97,32 @@ class URLSourceCollection:
     @property
     def unique_url_count(self) -> int:
         return len(set(self.yaml_urls) | set(self.document_urls))
+
+
+def _source_label(source_kind: SourceKind) -> str:
+    if source_kind == "yaml":
+        return "question files"
+    return "template files"
+
+
+def _url_message_id(*, severity: ReportSeverity, category: IssueCategory) -> str:
+    if category == "concatenated":
+        return (
+            MessageId.URL_CONCATENATED_ERROR
+            if severity == "error"
+            else MessageId.URL_CONCATENATED_WARNING
+        )
+    if category == "broken":
+        return (
+            MessageId.URL_BROKEN_ERROR
+            if severity == "error"
+            else MessageId.URL_BROKEN_WARNING
+        )
+    return (
+        MessageId.URL_UNREACHABLE_ERROR
+        if severity == "error"
+        else MessageId.URL_UNREACHABLE_WARNING
+    )
 
 
 def parse_args() -> argparse.Namespace:
@@ -782,7 +837,7 @@ def _append_issue(
     if severity == "ignore":
         return
     issues.append(
-        URLIssue(
+        URLIssue.create(
             severity=severity,
             category=category,
             source_kind=source_kind,
@@ -942,10 +997,6 @@ def print_url_check_report(result: URLCheckResult) -> None:
         print(f"Checked {result.checked_url_count} URLs; none returned HTTP 404/410.")
         return
 
-    source_labels = {
-        "yaml": "question files",
-        "template": "template files",
-    }
     title_labels = {
         "concatenated": (
             "Found malformed URL text that appears to contain another URL in {source}:"
@@ -968,16 +1019,11 @@ def print_url_check_report(result: URLCheckResult) -> None:
                 ]
                 if not bucket:
                     continue
-                print(title_labels[category].format(source=source_labels[source_kind]))
+                print(
+                    title_labels[category].format(source=_source_label(source_kind))
+                )
                 for issue in bucket:
-                    sources = ", ".join(issue.sources)
-                    if issue.status_code is None:
-                        print(f"- {issue.url} (found in: {sources})")
-                    else:
-                        print(
-                            f"- [{issue.status_code}] {issue.url} "
-                            f"(found in: {sources})"
-                        )
+                    print(f"- [{issue.code}] {issue.message}")
 
 
 def main() -> int:

--- a/src/dayamlchecker/messages.py
+++ b/src/dayamlchecker/messages.py
@@ -1,0 +1,685 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Mapping
+
+
+class Severity(StrEnum):
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class FindingClass(StrEnum):
+    GENERAL = "general"
+    ACCESSIBILITY = "accessibility"
+
+
+class MessageId(StrEnum):
+    YAML_DUPLICATE_KEY = "yaml_duplicate_key"
+    YAML_PARSE_ERROR = "yaml_parse_error"
+    YAML_STRING_REQUIRED = "yaml_string_required"
+
+    MAKO_SYNTAX_ERROR = "mako_syntax_error"
+    MAKO_COMPILE_ERROR = "mako_compile_error"
+    FIELD_VALUE_MAKO_SYNTAX_ERROR = "field_value_mako_syntax_error"
+    FIELD_VALUE_MAKO_COMPILE_ERROR = "field_value_mako_compile_error"
+
+    PYTHON_CODE_TYPE = "python_code_type"
+    PYTHON_SYNTAX_ERROR = "python_syntax_error"
+    VALIDATION_CODE_MISSING_VALIDATION_ERROR = (
+        "validation_code_missing_validation_error"
+    )
+    PYTHON_BOOL_NUMBER = "python_bool_number"
+    PYTHON_BOOL_TYPE = "python_bool_type"
+    PYTHON_BOOL_SYNTAX = "python_bool_syntax"
+
+    JS_MODIFIER_TYPE = "js_modifier_type"
+    JS_INVALID_SYNTAX = "js_invalid_syntax"
+    JS_MISSING_VAL_CALL = "js_missing_val_call"
+    JS_UNKNOWN_SCREEN_FIELD = "js_unknown_screen_field"
+    JS_UNKNOWN_SCREEN_FIELD_PARTIAL = "js_unknown_screen_field_partial"
+    JS_VAL_ARG_NOT_QUOTED = "js_val_arg_not_quoted"
+
+    UNKNOWN_KEYS = "unknown_keys"
+    SHOW_IF_MALFORMED = "show_if_malformed"
+    SHOW_IF_CODE_TYPE = "show_if_code_type"
+    SHOW_IF_CODE_SYNTAX = "show_if_code_syntax"
+    SHOW_IF_DICT_KEYS = "show_if_dict_keys"
+    NO_POSSIBLE_TYPES = "no_possible_types"
+    TOO_MANY_TYPES = "too_many_types"
+    INTERVIEW_ORDER_UNMATCHED_GUARD = "interview_order_unmatched_guard"
+    NESTED_VISIBILITY_LOGIC = "nested_visibility_logic"
+
+    PYTHON_VAR_TYPE = "python_var_type"
+    PYTHON_VAR_WHITESPACE = "python_var_whitespace"
+    OBJECTS_BLOCK_TYPE = "objects_block_type"
+    FIELDS_CODE_TYPE = "fields_code_type"
+    FIELDS_DICT_KEYS = "fields_dict_keys"
+    FIELDS_TYPE = "fields_type"
+    FIELD_MODIFIER_VARIABLE_TYPE = "field_modifier_variable_type"
+    FIELD_MODIFIER_UNKNOWN_VARIABLE_DICT = "field_modifier_unknown_variable_dict"
+    FIELD_MODIFIER_CODE_ERROR = "field_modifier_code_error"
+    FIELD_MODIFIER_SAME_SCREEN_CODE = "field_modifier_same_screen_code"
+    FIELD_MODIFIER_DICT_KEYS = "field_modifier_dict_keys"
+    FIELD_MODIFIER_UNKNOWN_VARIABLE_STRING = (
+        "field_modifier_unknown_variable_string"
+    )
+    FIELD_MODIFIER_CASE = "field_modifier_case"
+
+    ACCESSIBILITY_COMBOBOX_NOT_ACCESSIBLE = "accessibility_combobox_not_accessible"
+    ACCESSIBILITY_NO_LABEL_MULTI_FIELD = "accessibility_no_label_multi_field"
+    ACCESSIBILITY_TAGGED_PDF_NOT_ENABLED = (
+        "accessibility_tagged_pdf_not_enabled"
+    )
+    ACCESSIBILITY_THEME_CONTRAST_TOO_LOW = (
+        "accessibility_theme_contrast_too_low"
+    )
+    ACCESSIBILITY_IMAGE_MISSING_ALT_TEXT = (
+        "accessibility_image_missing_alt_text"
+    )
+    ACCESSIBILITY_MARKDOWN_HEADING_LEVEL_SKIP = (
+        "accessibility_markdown_heading_level_skip"
+    )
+    ACCESSIBILITY_HTML_HEADING_LEVEL_SKIP = (
+        "accessibility_html_heading_level_skip"
+    )
+    ACCESSIBILITY_EMPTY_LINK_TEXT = "accessibility_empty_link_text"
+    ACCESSIBILITY_NON_DESCRIPTIVE_LINK_TEXT = (
+        "accessibility_non_descriptive_link_text"
+    )
+
+    URL_CONCATENATED_ERROR = "url_concatenated_error"
+    URL_CONCATENATED_WARNING = "url_concatenated_warning"
+    URL_BROKEN_ERROR = "url_broken_error"
+    URL_BROKEN_WARNING = "url_broken_warning"
+    URL_UNREACHABLE_ERROR = "url_unreachable_error"
+    URL_UNREACHABLE_WARNING = "url_unreachable_warning"
+
+
+@dataclass(frozen=True, slots=True)
+class MessageDefinition:
+    code: str
+    severity: Severity
+    finding_class: FindingClass
+    summary: str
+    template: str
+
+
+MESSAGE_DEFINITIONS: dict[str, MessageDefinition] = {
+    MessageId.YAML_DUPLICATE_KEY: MessageDefinition(
+        code="EG101",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Duplicate YAML key",
+        template="{error}",
+    ),
+    MessageId.YAML_PARSE_ERROR: MessageDefinition(
+        code="EG102",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="YAML parsing error",
+        template="{error}",
+    ),
+    MessageId.YAML_STRING_REQUIRED: MessageDefinition(
+        code="EG103",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Expected a YAML string",
+        template="expected a YAML string, got {value_repr}",
+    ),
+    MessageId.MAKO_SYNTAX_ERROR: MessageDefinition(
+        code="EG111",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Invalid Mako syntax",
+        template="{error}",
+    ),
+    MessageId.MAKO_COMPILE_ERROR: MessageDefinition(
+        code="EG112",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Mako compile error",
+        template="{error}",
+    ),
+    MessageId.FIELD_VALUE_MAKO_SYNTAX_ERROR: MessageDefinition(
+        code="EG111",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Invalid Mako syntax",
+        template="{field_key} value has {error}",
+    ),
+    MessageId.FIELD_VALUE_MAKO_COMPILE_ERROR: MessageDefinition(
+        code="EG112",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Mako compile error",
+        template="{field_key} value has {error}",
+    ),
+    MessageId.PYTHON_CODE_TYPE: MessageDefinition(
+        code="EG121",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Python code block must be a YAML string",
+        template="code block must be a YAML string, got {value_type}",
+    ),
+    MessageId.PYTHON_SYNTAX_ERROR: MessageDefinition(
+        code="EG122",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Python syntax error",
+        template="Python syntax error: {error}",
+    ),
+    MessageId.VALIDATION_CODE_MISSING_VALIDATION_ERROR: MessageDefinition(
+        code="WG101",
+        severity=Severity.WARNING,
+        finding_class=FindingClass.GENERAL,
+        summary="Validation code may not show user-facing feedback",
+        template=(
+            "validation code does not call validation_error(); consider calling "
+            "validation_error(...) to provide user-facing error messages"
+        ),
+    ),
+    MessageId.PYTHON_BOOL_NUMBER: MessageDefinition(
+        code="EG131",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Expected a Python boolean or expression",
+        template="expected True, False, or a Python expression, got number: {value}",
+    ),
+    MessageId.PYTHON_BOOL_TYPE: MessageDefinition(
+        code="EG132",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Expected a Python boolean or expression",
+        template="expected True, False, or a Python expression, got: {value_type}",
+    ),
+    MessageId.PYTHON_BOOL_SYNTAX: MessageDefinition(
+        code="EG133",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Invalid Python boolean expression",
+        template=(
+            "expected True, False, or a valid Python expression, got: {value!r} "
+            "(Python syntax error: {error})"
+        ),
+    ),
+    MessageId.JS_MODIFIER_TYPE: MessageDefinition(
+        code="EG203",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="JavaScript modifier must be a string",
+        template="{modifier_key} must be a string, got {value_type}",
+    ),
+    MessageId.JS_INVALID_SYNTAX: MessageDefinition(
+        code="EG204",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Invalid JavaScript syntax",
+        template="invalid JavaScript syntax in {modifier_key}: {error}",
+    ),
+    MessageId.JS_MISSING_VAL_CALL: MessageDefinition(
+        code="EG205",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="JavaScript modifier must reference an on-screen field",
+        template=(
+            "{modifier_key} must contain at least one val() call to reference "
+            "an on-screen field"
+        ),
+    ),
+    MessageId.JS_UNKNOWN_SCREEN_FIELD: MessageDefinition(
+        code="EG206",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="JavaScript modifier references a missing on-screen field",
+        template=(
+            '{modifier_key} references val("{var_name}"), but "{var_name}" is '
+            "not defined on this screen"
+        ),
+    ),
+    MessageId.JS_UNKNOWN_SCREEN_FIELD_PARTIAL: MessageDefinition(
+        code="WG206",
+        severity=Severity.WARNING,
+        finding_class=FindingClass.GENERAL,
+        summary="JavaScript modifier could not be fully validated",
+        template=(
+            '{modifier_key} references val("{var_name}"), but "{var_name}" is not '
+            "defined on this screen (unable to fully validate screen variables "
+            "because this screen uses fields: code)"
+        ),
+    ),
+    MessageId.JS_VAL_ARG_NOT_QUOTED: MessageDefinition(
+        code="EG207",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="val() argument must be a quoted string literal",
+        template=(
+            'val() argument must be a quoted string literal, not "{bad_arg}". '
+            'Use val("...") or val(\'...\') instead'
+        ),
+    ),
+    MessageId.UNKNOWN_KEYS: MessageDefinition(
+        code="EG301",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Unknown YAML keys",
+        template="keys that should not appear in a docassemble block: {keys}",
+    ),
+    MessageId.SHOW_IF_MALFORMED: MessageDefinition(
+        code="EG302",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Malformed show if shorthand",
+        template=(
+            'show if value "{value}" appears malformed. Use YAML dict syntax: '
+            "show if: {{ variable: var_name, is: value }} or show if: {{ code: ... }}"
+        ),
+    ),
+    MessageId.SHOW_IF_CODE_TYPE: MessageDefinition(
+        code="EG303",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="show if: code must be a YAML string",
+        template="show if: code must be a YAML string",
+    ),
+    MessageId.SHOW_IF_CODE_SYNTAX: MessageDefinition(
+        code="EG304",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="show if: code has a Python syntax error",
+        template="show if: code has a Python syntax error: {error}",
+    ),
+    MessageId.SHOW_IF_DICT_KEYS: MessageDefinition(
+        code="EG305",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary='show if dict must include "variable" or "code"',
+        template='show if dict must include either "variable" or "code"',
+    ),
+    MessageId.NO_POSSIBLE_TYPES: MessageDefinition(
+        code="EG306",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="No recognized block type found",
+        template=(
+            "couldn't identify a block type: no valid combination of keys found "
+            "(looking for keys like question, include, metadata, code, objects, etc. "
+            "See https://docassemble.org/docs.html)"
+        ),
+    ),
+    MessageId.TOO_MANY_TYPES: MessageDefinition(
+        code="EG307",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Block matches too many exclusive interview types",
+        template="block matches too many exclusive interview types: {block_types}",
+    ),
+    MessageId.INTERVIEW_ORDER_UNMATCHED_GUARD: MessageDefinition(
+        code="EG308",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Interview-order block is missing a matching show/hide guard",
+        template=(
+            'interview-order style block references "{field_name}" without a matching '
+            "guard for that field's show/hide logic; this can cause the interview "
+            "to get stuck"
+        ),
+    ),
+    MessageId.NESTED_VISIBILITY_LOGIC: MessageDefinition(
+        code="WG309",
+        severity=Severity.WARNING,
+        finding_class=FindingClass.GENERAL,
+        summary="Show/hide visibility logic is nested too deeply",
+        template=(
+            "show if/hide if visibility logic is nested {nesting_depth} levels on "
+            "this screen (more than 2)"
+        ),
+    ),
+    MessageId.PYTHON_VAR_TYPE: MessageDefinition(
+        code="EG401",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Python variable reference must be a YAML string",
+        template="the Python variable reference must be a YAML string, got {value_repr}",
+    ),
+    MessageId.PYTHON_VAR_WHITESPACE: MessageDefinition(
+        code="EG402",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Python variable reference cannot contain whitespace",
+        template="the Python variable reference cannot contain whitespace, got {value}",
+    ),
+    MessageId.OBJECTS_BLOCK_TYPE: MessageDefinition(
+        code="EG403",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="objects block must be a list or dict",
+        template="objects block must be a list or dict, got {value_repr}",
+    ),
+    MessageId.FIELDS_CODE_TYPE: MessageDefinition(
+        code="EG404",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="fields: code must be a YAML string",
+        template="fields: code must be a YAML string, got {value_type}",
+    ),
+    MessageId.FIELDS_DICT_KEYS: MessageDefinition(
+        code="EG405",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary='fields dict must contain a "code" key',
+        template=(
+            'fields dict must contain a "code" key when written as a mapping, '
+            "got {value_repr}"
+        ),
+    ),
+    MessageId.FIELDS_TYPE: MessageDefinition(
+        code="EG406",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="fields must be a list or dict",
+        template="fields must be a list or dict, got {value_repr}",
+    ),
+    MessageId.FIELD_MODIFIER_VARIABLE_TYPE: MessageDefinition(
+        code="EG407",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Field modifier variable must be a string",
+        template="{modifier_key}: variable must be a string, got {value_type}",
+    ),
+    MessageId.FIELD_MODIFIER_UNKNOWN_VARIABLE_DICT: MessageDefinition(
+        code="EG408",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Field modifier references a field not defined on this screen",
+        template=(
+            '{modifier_key}: variable "{variable}" is not defined on this screen. '
+            "Use {modifier_key}: {{ code: ... }} instead for variables from previous screens"
+        ),
+    ),
+    MessageId.FIELD_MODIFIER_CODE_ERROR: MessageDefinition(
+        code="EG409",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Field modifier code contains another validation error",
+        template="{modifier_key}: code has {detail}",
+    ),
+    MessageId.FIELD_MODIFIER_SAME_SCREEN_CODE: MessageDefinition(
+        code="EG410",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="show if: code references a variable defined on this screen",
+        template=(
+            "{modifier_key}: code references variable(s) defined on this screen "
+            "({variables}). Use {modifier_key}: <var> or {modifier_key}: "
+            "{{ variable: <var>, is: ... }} instead"
+        ),
+    ),
+    MessageId.FIELD_MODIFIER_DICT_KEYS: MessageDefinition(
+        code="EG411",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary='Field modifier dict must include "variable" or "code"',
+        template='{modifier_key} dict must include either "variable" or "code"',
+    ),
+    MessageId.FIELD_MODIFIER_UNKNOWN_VARIABLE_STRING: MessageDefinition(
+        code="EG412",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Field modifier shorthand references a field not defined on this screen",
+        template=(
+            '{modifier_key}: "{variable}" is not defined on this screen. Use '
+            "{modifier_key}: {{ code: ... }} instead for variables from previous screens"
+        ),
+    ),
+    MessageId.FIELD_MODIFIER_CASE: MessageDefinition(
+        code="EG413",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Invalid field modifier key casing",
+        template=(
+            'invalid field key "{field_key}". docassemble field modifier keys are '
+            'case-sensitive; use "{suggested_key}"'
+        ),
+    ),
+    MessageId.ACCESSIBILITY_COMBOBOX_NOT_ACCESSIBLE: MessageDefinition(
+        code="EA501",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="Combobox widget is not accessible",
+        template="{subject} uses `combobox`, which is not allowed for accessibility reasons",
+    ),
+    MessageId.ACCESSIBILITY_NO_LABEL_MULTI_FIELD: MessageDefinition(
+        code="EA502",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="Field label is missing on a multi-field screen",
+        template=(
+            "`no label` or an empty/missing field label is only allowed on "
+            "single-field screens; this screen has {field_count} fields: {field_name}"
+        ),
+    ),
+    MessageId.ACCESSIBILITY_TAGGED_PDF_NOT_ENABLED: MessageDefinition(
+        code="IA503",
+        severity=Severity.INFO,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="DOCX attachment is missing tagged pdf",
+        template=(
+            "DOCX attachment detected without `tagged pdf: True`; set it on "
+            "`features` or the attachment to improve generated PDF accessibility"
+        ),
+    ),
+    MessageId.ACCESSIBILITY_THEME_CONTRAST_TOO_LOW: MessageDefinition(
+        code="EA504",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="Bootstrap theme CSS has low contrast",
+        template=(
+            "bootstrap theme CSS has low contrast for {component} "
+            "(ratio {ratio:.2f}:1, expected at least {minimum_ratio:.1f}:1)"
+        ),
+    ),
+    MessageId.ACCESSIBILITY_IMAGE_MISSING_ALT_TEXT: MessageDefinition(
+        code="EA505",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="Image is missing alt text",
+        template="{image_kind} in {section_location} is missing alt text: {snippet}",
+    ),
+    MessageId.ACCESSIBILITY_MARKDOWN_HEADING_LEVEL_SKIP: MessageDefinition(
+        code="EA506",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="Markdown heading levels skip",
+        template=(
+            "markdown heading levels skip from H{previous_level} to H{current_level} "
+            "in {section_location}: {snippet}"
+        ),
+    ),
+    MessageId.ACCESSIBILITY_HTML_HEADING_LEVEL_SKIP: MessageDefinition(
+        code="EA507",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="HTML heading levels skip",
+        template=(
+            "HTML heading levels skip from H{previous_level} to H{current_level} "
+            "in {section_location}: {snippet}"
+        ),
+    ),
+    MessageId.ACCESSIBILITY_EMPTY_LINK_TEXT: MessageDefinition(
+        code="EA508",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="Link has no accessible text",
+        template="link in {section_location} has no accessible text: {snippet}",
+    ),
+    MessageId.ACCESSIBILITY_NON_DESCRIPTIVE_LINK_TEXT: MessageDefinition(
+        code="EA509",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.ACCESSIBILITY,
+        summary="Link text is too generic",
+        template="link text in {section_location} is too generic: {text}",
+    ),
+    MessageId.URL_CONCATENATED_ERROR: MessageDefinition(
+        code="EG601",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="Malformed URL text appears to contain another URL",
+        template=(
+            "malformed URL text appears to contain another URL in {source_label}: "
+            "{url} (found in: {sources})"
+        ),
+    ),
+    MessageId.URL_CONCATENATED_WARNING: MessageDefinition(
+        code="WG601",
+        severity=Severity.WARNING,
+        finding_class=FindingClass.GENERAL,
+        summary="Malformed URL text appears to contain another URL",
+        template=(
+            "malformed URL text appears to contain another URL in {source_label}: "
+            "{url} (found in: {sources})"
+        ),
+    ),
+    MessageId.URL_BROKEN_ERROR: MessageDefinition(
+        code="EG602",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="URL returned HTTP 404/410",
+        template=(
+            "URL returned HTTP {status_code} in {source_label}: {url} "
+            "(found in: {sources})"
+        ),
+    ),
+    MessageId.URL_BROKEN_WARNING: MessageDefinition(
+        code="WG602",
+        severity=Severity.WARNING,
+        finding_class=FindingClass.GENERAL,
+        summary="URL returned HTTP 404/410",
+        template=(
+            "URL returned HTTP {status_code} in {source_label}: {url} "
+            "(found in: {sources})"
+        ),
+    ),
+    MessageId.URL_UNREACHABLE_ERROR: MessageDefinition(
+        code="EG603",
+        severity=Severity.ERROR,
+        finding_class=FindingClass.GENERAL,
+        summary="URL could not be reached",
+        template=(
+            "could not reach URL in {source_label} to verify it: {url} "
+            "(found in: {sources})"
+        ),
+    ),
+    MessageId.URL_UNREACHABLE_WARNING: MessageDefinition(
+        code="WG603",
+        severity=Severity.WARNING,
+        finding_class=FindingClass.GENERAL,
+        summary="URL could not be reached",
+        template=(
+            "could not reach URL in {source_label} to verify it: {url} "
+            "(found in: {sources})"
+        ),
+    ),
+}
+
+
+def get_message_definition(message_id: str) -> MessageDefinition:
+    return MESSAGE_DEFINITIONS[message_id]
+
+
+def render_message(message_id: str, context: Mapping[str, Any]) -> str:
+    return get_message_definition(message_id).template.format(**context)
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    message_id: str
+    file_name: str | None = None
+    line_number: int | None = None
+    context: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def definition(self) -> MessageDefinition:
+        return get_message_definition(self.message_id)
+
+    @property
+    def code(self) -> str:
+        return self.definition.code
+
+    @property
+    def severity(self) -> Severity:
+        return self.definition.severity
+
+    @property
+    def finding_class(self) -> FindingClass:
+        return self.definition.finding_class
+
+    @property
+    def summary(self) -> str:
+        return self.definition.summary
+
+    @property
+    def message(self) -> str:
+        return render_message(self.message_id, self.context)
+
+    @property
+    def err_str(self) -> str:
+        return self.message
+
+    def __str__(self) -> str:
+        location = self.file_name or "<unknown>"
+        if self.line_number is not None:
+            location = f"{location}:{self.line_number}"
+        return f"At {location}: [{self.code}] {self.message}"
+
+
+@dataclass(frozen=True, slots=True)
+class FindingDraft:
+    message_id: str
+    line_number: int = 1
+    context: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def definition(self) -> MessageDefinition:
+        return get_message_definition(self.message_id)
+
+    @property
+    def code(self) -> str:
+        return self.definition.code
+
+    @property
+    def severity(self) -> Severity:
+        return self.definition.severity
+
+    @property
+    def message(self) -> str:
+        return render_message(self.message_id, self.context)
+
+    def to_finding(self, *, file_name: str, line_number: int | None = None) -> Finding:
+        return Finding(
+            message_id=self.message_id,
+            file_name=file_name,
+            line_number=self.line_number if line_number is None else line_number,
+            context=self.context,
+        )
+
+
+def draft(message_id: str, line_number: int = 1, **context: Any) -> FindingDraft:
+    return FindingDraft(message_id=message_id, line_number=line_number, context=context)
+
+
+def make_finding(
+    message_id: str,
+    *,
+    file_name: str | None = None,
+    line_number: int | None = None,
+    **context: Any,
+) -> Finding:
+    return Finding(
+        message_id=message_id,
+        file_name=file_name,
+        line_number=line_number,
+        context=context,
+    )

--- a/src/dayamlchecker/messages.py
+++ b/src/dayamlchecker/messages.py
@@ -63,32 +63,20 @@ class MessageId(StrEnum):
     FIELD_MODIFIER_CODE_ERROR = "field_modifier_code_error"
     FIELD_MODIFIER_SAME_SCREEN_CODE = "field_modifier_same_screen_code"
     FIELD_MODIFIER_DICT_KEYS = "field_modifier_dict_keys"
-    FIELD_MODIFIER_UNKNOWN_VARIABLE_STRING = (
-        "field_modifier_unknown_variable_string"
-    )
+    FIELD_MODIFIER_UNKNOWN_VARIABLE_STRING = "field_modifier_unknown_variable_string"
     FIELD_MODIFIER_CASE = "field_modifier_case"
 
     ACCESSIBILITY_COMBOBOX_NOT_ACCESSIBLE = "accessibility_combobox_not_accessible"
     ACCESSIBILITY_NO_LABEL_MULTI_FIELD = "accessibility_no_label_multi_field"
-    ACCESSIBILITY_TAGGED_PDF_NOT_ENABLED = (
-        "accessibility_tagged_pdf_not_enabled"
-    )
-    ACCESSIBILITY_THEME_CONTRAST_TOO_LOW = (
-        "accessibility_theme_contrast_too_low"
-    )
-    ACCESSIBILITY_IMAGE_MISSING_ALT_TEXT = (
-        "accessibility_image_missing_alt_text"
-    )
+    ACCESSIBILITY_TAGGED_PDF_NOT_ENABLED = "accessibility_tagged_pdf_not_enabled"
+    ACCESSIBILITY_THEME_CONTRAST_TOO_LOW = "accessibility_theme_contrast_too_low"
+    ACCESSIBILITY_IMAGE_MISSING_ALT_TEXT = "accessibility_image_missing_alt_text"
     ACCESSIBILITY_MARKDOWN_HEADING_LEVEL_SKIP = (
         "accessibility_markdown_heading_level_skip"
     )
-    ACCESSIBILITY_HTML_HEADING_LEVEL_SKIP = (
-        "accessibility_html_heading_level_skip"
-    )
+    ACCESSIBILITY_HTML_HEADING_LEVEL_SKIP = "accessibility_html_heading_level_skip"
     ACCESSIBILITY_EMPTY_LINK_TEXT = "accessibility_empty_link_text"
-    ACCESSIBILITY_NON_DESCRIPTIVE_LINK_TEXT = (
-        "accessibility_non_descriptive_link_text"
-    )
+    ACCESSIBILITY_NON_DESCRIPTIVE_LINK_TEXT = "accessibility_non_descriptive_link_text"
 
     URL_CONCATENATED_ERROR = "url_concatenated_error"
     URL_CONCATENATED_WARNING = "url_concatenated_warning"
@@ -257,7 +245,7 @@ MESSAGE_DEFINITIONS: dict[str, MessageDefinition] = {
         summary="val() argument must be a quoted string literal",
         template=(
             'val() argument must be a quoted string literal, not "{bad_arg}". '
-            'Use val("...") or val(\'...\') instead'
+            "Use val(\"...\") or val('...') instead"
         ),
     ),
     MessageId.UNKNOWN_KEYS: MessageDefinition(

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -11,6 +11,7 @@ from dayamlchecker.accessibility import (
     AccessibilityLintOptions,
     find_accessibility_findings,
 )
+from dayamlchecker.messages import Finding, MessageId, draft, make_finding
 from mako.template import Template as MakoTemplate  # type: ignore[import-untyped]
 from mako.exceptions import (  # type: ignore[import-untyped]
     SyntaxException,
@@ -86,7 +87,9 @@ class YAMLStr:
     def __init__(self, x):
         self.errors = []
         if not isinstance(x, str):
-            self.errors = [(f"{x} isn't a string", 1)]
+            self.errors = [
+                draft(MessageId.YAML_STRING_REQUIRED, value_repr=repr(x))
+            ]
 
 
 class MakoText:
@@ -99,9 +102,21 @@ class MakoText:
                 x, strict_undefined=True, input_encoding="utf-8"
             )
         except SyntaxException as ex:
-            self.errors = [(ex, ex.lineno)]
+            self.errors = [
+                draft(
+                    MessageId.MAKO_SYNTAX_ERROR,
+                    line_number=ex.lineno or 1,
+                    error=str(ex),
+                )
+            ]
         except CompileException as ex:
-            self.errors = [(ex, ex.lineno)]
+            self.errors = [
+                draft(
+                    MessageId.MAKO_COMPILE_ERROR,
+                    line_number=ex.lineno or 1,
+                    error=str(ex),
+                )
+            ]
 
 
 class MakoMarkdownText(MakoText):
@@ -123,7 +138,7 @@ class PythonText:
         self.errors = []
         if not isinstance(x, str):
             self.errors = [
-                (f"code block must be a YAML string, is {type(x).__name__}", 1)
+                draft(MessageId.PYTHON_CODE_TYPE, value_type=type(x).__name__)
             ]
             return
         try:
@@ -132,7 +147,9 @@ class PythonText:
             # ex.lineno gives line number within the code block
             lineno = ex.lineno or 1
             msg = ex.msg or str(ex)
-            self.errors = [(f"Python syntax error: {msg}", lineno)]
+            self.errors = [
+                draft(MessageId.PYTHON_SYNTAX_ERROR, line_number=lineno, error=msg)
+            ]
 
 
 class ValidationCode(PythonText):
@@ -191,10 +208,7 @@ class ValidationCode(PythonText):
             # Otherwise, emit a warning suggesting use of validation_error().
             # Use line number 1 because we don't have a more specific mapping here
             self.errors.append(
-                (
-                    "validation code does not call validation_error(); consider calling validation_error(...) to provide user-facing error messages",
-                    1,
-                )
+                draft(MessageId.VALIDATION_CODE_MISSING_VALIDATION_ERROR)
             )
 
 
@@ -207,18 +221,11 @@ class PythonBool:
             return
         # number like 10 or 0 - not valid, even though Python treats them as truthy/falsy
         if isinstance(x, (int, float)):
-            self.errors = [
-                (f"expected True, False, or a Python expression, got number: {x}", 1)
-            ]
+            self.errors = [draft(MessageId.PYTHON_BOOL_NUMBER, value=x)]
             return
         # must be a string at this point
         if not isinstance(x, str):
-            self.errors = [
-                (
-                    f"expected True, False, or a Python expression, got: {type(x).__name__}",
-                    1,
-                )
-            ]
+            self.errors = [draft(MessageId.PYTHON_BOOL_TYPE, value_type=type(x).__name__)]
             return
         # try parsing it as a Python expression - covers things like "user_age > 18"
         try:
@@ -226,10 +233,7 @@ class PythonBool:
         except SyntaxError as ex:
             msg = ex.msg or str(ex)
             self.errors = [
-                (
-                    f"expected True, False, or a valid Python expression, got: {x!r} (Python syntax error: {msg})",
-                    1,
-                )
+                draft(MessageId.PYTHON_BOOL_SYNTAX, value=x, error=msg)
             ]
 
 
@@ -253,7 +257,11 @@ class JSShowIf:
         self.screen_variables = screen_variables or set()
         if not isinstance(x, str):
             self.errors = [
-                (f"{modifier_key} must be a string, is {type(x).__name__}", 1)
+                draft(
+                    MessageId.JS_MODIFIER_TYPE,
+                    modifier_key=modifier_key,
+                    value_type=type(x).__name__,
+                )
             ]
             return
 
@@ -266,9 +274,11 @@ class JSShowIf:
             parsed = esprima.parseScript(js_to_check, tolerant=False, loc=True).toDict()
         except esprima.Error as ex:
             self.errors.append(
-                (
-                    f"Invalid JavaScript syntax in {modifier_key}: {ex}",
-                    getattr(ex, "lineNumber", 1) or 1,
+                draft(
+                    MessageId.JS_INVALID_SYNTAX,
+                    line_number=getattr(ex, "lineNumber", 1) or 1,
+                    modifier_key=modifier_key,
+                    error=str(ex),
                 )
             )
             return
@@ -292,10 +302,7 @@ class JSShowIf:
 
         if not val_calls:
             self.errors.append(
-                (
-                    f"{modifier_key} must contain at least one val() call to reference an on-screen field",
-                    1,
-                )
+                draft(MessageId.JS_MISSING_VAL_CALL, modifier_key=modifier_key)
             )
 
         for call in val_calls:
@@ -312,9 +319,14 @@ class JSShowIf:
                     var_name
                 ):
                     self.errors.append(
-                        (
-                            f'{modifier_key} references val("{var_name}"), but "{var_name}" is not defined on this screen',
-                            (call.get("loc", {}).get("start", {}).get("line", 1) or 1),
+                        draft(
+                            MessageId.JS_UNKNOWN_SCREEN_FIELD,
+                            line_number=(
+                                call.get("loc", {}).get("start", {}).get("line", 1)
+                                or 1
+                            ),
+                            modifier_key=modifier_key,
+                            var_name=var_name,
                         )
                     )
                 continue
@@ -327,9 +339,12 @@ class JSShowIf:
                     or first_arg.get("type", "<unknown>")
                 )
             self.errors.append(
-                (
-                    f'val() argument must be a quoted string literal, not "{bad_arg}". Use val("...") or val(\'...\') instead',
-                    (call.get("loc", {}).get("start", {}).get("line", 1) or 1),
+                draft(
+                    MessageId.JS_VAL_ARG_NOT_QUOTED,
+                    line_number=(
+                        call.get("loc", {}).get("start", {}).get("line", 1) or 1
+                    ),
+                    bad_arg=bad_arg,
                 )
             )
 
@@ -383,10 +398,7 @@ class ShowIf:
             elif x.startswith("variable:") or x.startswith("code:"):
                 # Malformed - these should be YAML dict format
                 self.errors.append(
-                    (
-                        f'show if value "{x}" appears to be malformed. Use YAML dict syntax: show if: {{ variable: var_name, is: value }} or show if: {{ code: ... }}',
-                        1,
-                    )
+                    draft(MessageId.SHOW_IF_MALFORMED, value=x)
                 )
         elif isinstance(x, dict):
             # YAML dict form
@@ -399,12 +411,7 @@ class ShowIf:
                 # Validate Python syntax for the provided code block
                 code_block = x.get("code")
                 if not isinstance(code_block, str):
-                    self.errors.append(
-                        (
-                            f"show if: code must be a YAML string",
-                            1,
-                        )
-                    )
+                    self.errors.append(draft(MessageId.SHOW_IF_CODE_TYPE))
                 else:
                     try:
                         ast.parse(code_block)
@@ -412,15 +419,14 @@ class ShowIf:
                         lineno = ex.lineno or 1
                         msg = ex.msg or str(ex)
                         self.errors.append(
-                            (
-                                f"show if: code has Python syntax error: {msg}",
-                                lineno,
+                            draft(
+                                MessageId.SHOW_IF_CODE_SYNTAX,
+                                line_number=lineno,
+                                error=msg,
                             )
                         )
             else:
-                self.errors.append(
-                    (f'show if dict must have either "variable" key or "code" key', 1)
-                )
+                self.errors.append(draft(MessageId.SHOW_IF_DICT_KEYS))
 
 
 class DAPythonVar:
@@ -429,9 +435,9 @@ class DAPythonVar:
     def __init__(self, x):
         self.errors = []
         if not isinstance(x, str):
-            self.errors = [(f"The python var needs to be a YAML string, is {x}", 1)]
+            self.errors = [draft(MessageId.PYTHON_VAR_TYPE, value_repr=repr(x))]
         elif " " in x and not space_in_str.search(x):
-            self.errors = [(f"The python var cannot have whitespace (is {x})", 1)]
+            self.errors = [draft(MessageId.PYTHON_VAR_WHITESPACE, value=x)]
 
 
 class DAType:
@@ -447,7 +453,7 @@ class ObjectsAttrType:
         # The full typing desc of the var: TODO: how to use this?
         self.errors = []
         if not (isinstance(x, list) or isinstance(x, dict)):
-            self.errors = [f"Objects block needs to be a list or a dict, is {x}"]
+            self.errors = [draft(MessageId.OBJECTS_BLOCK_TYPE, value_repr=repr(x))]
         # for entry in x:
         #   ...
         # if not isinstance(x, Union[list[dict[DAPythonVar, DAType]], dict[DAPythonVar, DAType]]):
@@ -486,18 +492,18 @@ class DAFields:
         self.has_dynamic_fields_code = False
         if isinstance(x, dict):
             if "code" not in x:
-                self.errors = [(f'fields dict must have "code" key, is {x}', 1)]
+                self.errors = [draft(MessageId.FIELDS_DICT_KEYS, value_repr=repr(x))]
                 return
             if not isinstance(x.get("code"), str):
                 self.errors = [
-                    (
-                        f'fields: code must be a YAML string, is {type(x.get("code")).__name__}',
-                        1,
+                    draft(
+                        MessageId.FIELDS_CODE_TYPE,
+                        value_type=type(x.get("code")).__name__,
                     )
                 ]
             return
         if not isinstance(x, list):
-            self.errors = [(f"fields should be a list or dict, is {x}", 1)]
+            self.errors = [draft(MessageId.FIELDS_TYPE, value_repr=repr(x))]
             return
         self._validate_field_modifiers(x)
 
@@ -547,16 +553,20 @@ class DAFields:
                 ref_var = modifier_value.get("variable")
                 if not isinstance(ref_var, str):
                     self.errors.append(
-                        (
-                            f"{modifier_key}: variable must be a string, got {type(ref_var).__name__}",
-                            self._line_for(field_item),
+                        draft(
+                            MessageId.FIELD_MODIFIER_VARIABLE_TYPE,
+                            line_number=self._line_for(field_item),
+                            modifier_key=modifier_key,
+                            value_type=type(ref_var).__name__,
                         )
                     )
                 elif not references_screen_variable(ref_var):
                     self.errors.append(
-                        (
-                            f"{modifier_key}: variable: {ref_var} is not defined on this screen. Use {modifier_key}: {{ code: ... }} instead for variables from previous screens",
-                            self._line_for(field_item),
+                        draft(
+                            MessageId.FIELD_MODIFIER_UNKNOWN_VARIABLE_DICT,
+                            line_number=self._line_for(field_item),
+                            modifier_key=modifier_key,
+                            variable=ref_var,
                         )
                     )
             elif "code" in modifier_value:
@@ -564,9 +574,11 @@ class DAFields:
                 validator = PythonText(code_text)
                 for err in validator.errors:
                     self.errors.append(
-                        (
-                            f"{modifier_key}: code has {err[0].lower()}",
-                            self._line_for(field_item, err[1]),
+                        draft(
+                            MessageId.FIELD_MODIFIER_CODE_ERROR,
+                            line_number=self._line_for(field_item, err.line_number or 1),
+                            modifier_key=modifier_key,
+                            detail=err.message.lower(),
                         )
                     )
                 if (
@@ -580,24 +592,29 @@ class DAFields:
                     if same_screen_refs:
                         refs = ", ".join(sorted(same_screen_refs))
                         self.errors.append(
-                            (
-                                f"{modifier_key}: code references variable(s) defined on this screen ({refs}). Use {modifier_key}: <var> or {modifier_key}: {{ variable: <var>, is: ... }} instead",
-                                self._line_for(field_item),
+                            draft(
+                                MessageId.FIELD_MODIFIER_SAME_SCREEN_CODE,
+                                line_number=self._line_for(field_item),
+                                modifier_key=modifier_key,
+                                variables=refs,
                             )
                         )
             else:
                 self.errors.append(
-                    (
-                        f'{modifier_key} dict must have either "variable" or "code"',
-                        self._line_for(field_item),
+                    draft(
+                        MessageId.FIELD_MODIFIER_DICT_KEYS,
+                        line_number=self._line_for(field_item),
+                        modifier_key=modifier_key,
                     )
                 )
         elif isinstance(modifier_value, str) and ":" not in modifier_value:
             if not references_screen_variable(modifier_value):
                 self.errors.append(
-                    (
-                        f"{modifier_key}: {modifier_value} is not defined on this screen. Use {modifier_key}: {{ code: ... }} instead for variables from previous screens",
-                        self._line_for(field_item),
+                    draft(
+                        MessageId.FIELD_MODIFIER_UNKNOWN_VARIABLE_STRING,
+                        line_number=self._line_for(field_item),
+                        modifier_key=modifier_key,
+                        variable=modifier_value,
                     )
                 )
 
@@ -643,18 +660,29 @@ class DAFields:
                         and field_key.lower() in self.modifier_keys
                     ):
                         self.errors.append(
-                            (
-                                f'Invalid field key "{field_key}". docassemble field modifier keys are case-sensitive; use "{field_key.lower()}"',
-                                self._line_for(field_item),
+                            draft(
+                                MessageId.FIELD_MODIFIER_CASE,
+                                line_number=self._line_for(field_item),
+                                field_key=field_key,
+                                suggested_key=field_key.lower(),
                             )
                         )
                     if field_key in self.mako_keys:
                         the_mako = MakoText(str(field_item[field_key]))
                         for err in the_mako.errors:
+                            field_message_id = (
+                                MessageId.FIELD_VALUE_MAKO_SYNTAX_ERROR
+                                if err.message_id == MessageId.MAKO_SYNTAX_ERROR
+                                else MessageId.FIELD_VALUE_MAKO_COMPILE_ERROR
+                            )
                             self.errors.append(
-                                (
-                                    f"{field_key} value has {err[0]}",
-                                    self._line_for(field_item, err[1]),
+                                draft(
+                                    field_message_id,
+                                    line_number=self._line_for(
+                                        field_item, err.line_number or 1
+                                    ),
+                                    field_key=field_key,
+                                    **dict(err.context),
                                 )
                             )
 
@@ -666,18 +694,28 @@ class DAFields:
                         screen_variables=screen_variables,
                     )
                     for err in validator.errors:
-                        err_msg = err[0]
                         if (
                             self.has_dynamic_fields_code
-                            and "not defined on this screen" in err_msg.lower()
+                            and err.message_id == MessageId.JS_UNKNOWN_SCREEN_FIELD
                         ):
-                            err_msg = (
-                                "Warning: "
-                                + err_msg
-                                + " (unable to fully validate screen variables because this screen uses fields: code)"
+                            self.errors.append(
+                                draft(
+                                    MessageId.JS_UNKNOWN_SCREEN_FIELD_PARTIAL,
+                                    line_number=self._line_for(
+                                        field_item, err.line_number or 1
+                                    ),
+                                    **dict(err.context),
+                                )
                             )
+                            continue
                         self.errors.append(
-                            (err_msg, self._line_for(field_item, err[1]))
+                            draft(
+                                err.message_id,
+                                line_number=self._line_for(
+                                    field_item, err.line_number or 1
+                                ),
+                                **dict(err.context),
+                            )
                         )
 
             for py_key in self.py_modifier_keys:
@@ -1130,25 +1168,14 @@ def _get_case_insensitive(
     return mapping.get(original_key, default)
 
 
-class YAMLError:
-    def __init__(
-        self,
-        *,
-        err_str: str,
-        line_number: int,
-        file_name: str,
-        experimental: bool = True,
-    ):
-        self.err_str = err_str
-        self.line_number = line_number
-        self.file_name = file_name
-        self.experimental = experimental
-        pass
+YAMLError = Finding
 
-    def __str__(self):
-        if not self.experimental:
-            return f"REAL ERROR: At {self.file_name}:{self.line_number}: {self.err_str}"
-        return f"At {self.file_name}:{self.line_number}: {self.err_str}"
+
+def _yaml_error_message_id(error_text: str) -> str:
+    lowered = error_text.lower()
+    if "duplicate key" in lowered or "found duplicate key" in lowered:
+        return MessageId.YAML_DUPLICATE_KEY
+    return MessageId.YAML_PARSE_ERROR
 
 
 def _make_yaml_parser() -> YAML:
@@ -1497,14 +1524,14 @@ def find_errors_from_string(
     lint_mode: str = DEFAULT_LINT_MODE,
     runtime_options: Optional[RuntimeOptions] = None,
 ) -> list[YAMLError]:
-    """Return list of YAMLError found in the given full_content string
+    """Return list of findings found in the given full_content string
 
     Args:
         full_content (str): Full YAML content as a string.
     Returns:
-        list[YAMLError]: List of YAMLError instances found in the content.
+        list[YAMLError]: List of findings found in the content.
     """
-    all_errors = []
+    all_errors: list[YAMLError] = []
     runtime_options = runtime_options or RuntimeOptions()
 
     if not input_file:
@@ -1530,12 +1557,13 @@ def find_errors_from_string(
                     errMess.context_mark.line += line_number - 1
                 if errMess.problem_mark is not None:
                     errMess.problem_mark.line += line_number - 1
+            rendered_error = str(errMess)
             all_errors.append(
-                YAMLError(
-                    err_str=str(errMess),
+                make_finding(
+                    _yaml_error_message_id(rendered_error),
                     line_number=line_number,
                     file_name=input_file,
-                    experimental=False,
+                    error=rendered_error,
                 )
             )
             line_number += lines_in_code
@@ -1557,14 +1585,7 @@ def find_errors_from_string(
                 input_file=input_file,
                 options=runtime_options.accessibility_options(),
             )
-            for finding in accessibility_findings:
-                all_errors.append(
-                    YAMLError(
-                        err_str=finding.message,
-                        line_number=finding.line_number,
-                        file_name=input_file,
-                    )
-                )
+            all_errors.extend(accessibility_findings)
 
         doc_keys_lower = _lowercase_key_map(doc)
         non_meta_keys_lower = {
@@ -1584,11 +1605,8 @@ def find_errors_from_string(
             ]
             if len(any_types) == 0:
                 all_errors.append(
-                    YAMLError(
-                        err_str=(
-                            "Couldn't identify a block type: no valid combination of keys found "
-                            "(looking for keys like question, include, metadata, code, objects, etc. See https://docassemble.org/docs.html)"
-                        ),
+                    make_finding(
+                        MessageId.NO_POSSIBLE_TYPES,
                         line_number=line_number,
                         file_name=input_file,
                     )
@@ -1601,10 +1619,11 @@ def find_errors_from_string(
                 pass
             else:
                 all_errors.append(
-                    YAMLError(
-                        err_str=f"Too many types this block could be: {posb_types}",
+                    make_finding(
+                        MessageId.TOO_MANY_TYPES,
                         line_number=line_number,
                         file_name=input_file,
+                        block_types=", ".join(posb_types),
                     )
                 )
 
@@ -1619,11 +1638,11 @@ def find_errors_from_string(
                 weird_keys.append(attr)
         if len(weird_keys) > 0:
             all_errors.append(
-                YAMLError(
-                    err_str=f"Keys that shouldn't exist! {weird_keys}",
+                make_finding(
+                    MessageId.UNKNOWN_KEYS,
                     line_number=line_number,
                     file_name=input_file,
-                    experimental=False,
+                    keys=", ".join(weird_keys),
                 )
             )
         for key in doc.keys():
@@ -1634,10 +1653,11 @@ def find_errors_from_string(
                 test = big_dict[lower_key]["type"](doc[key])
                 for err in test.errors:
                     all_errors.append(
-                        YAMLError(
-                            err_str=f"{err[0]}",
-                            line_number=err[1] + doc["__line__"] + line_number,
+                        err.to_finding(
                             file_name=input_file,
+                            line_number=(err.line_number or 1)
+                            + doc["__line__"]
+                            + line_number,
                         )
                     )
 
@@ -1646,26 +1666,22 @@ def find_errors_from_string(
         )
         for field_var, ref_line in unmatched_refs:
             all_errors.append(
-                YAMLError(
-                    err_str=(
-                        f'interview-order style block references "{field_var}" without a matching guard '
-                        f"for that field's show/hide logic; this can cause the interview to get stuck"
-                    ),
+                make_finding(
+                    MessageId.INTERVIEW_ORDER_UNMATCHED_GUARD,
                     line_number=doc["__line__"] + line_number + ref_line,
                     file_name=input_file,
+                    field_name=field_var,
                 )
             )
 
         nesting_depth = _max_screen_visibility_nesting_depth(doc)
         if nesting_depth > 2:
             all_errors.append(
-                YAMLError(
-                    err_str=(
-                        f"Warning: show if/hide if visibility logic is nested {nesting_depth} levels "
-                        "on this screen (more than 2)"
-                    ),
+                make_finding(
+                    MessageId.NESTED_VISIBILITY_LOGIC,
                     line_number=doc["__line__"] + line_number,
                     file_name=input_file,
+                    nesting_depth=nesting_depth,
                 )
             )
 
@@ -1682,7 +1698,7 @@ def find_errors(
     lint_mode: str = DEFAULT_LINT_MODE,
     runtime_options: Optional[RuntimeOptions] = None,
 ) -> list[YAMLError]:
-    """Return list of YAMLError found in the given input_file
+    """Return list of findings found in the given input_file
 
     If the file has Docassemble's optional Jinja2 preprocessor directive at the top,
     it is ignored and an empty list is returned.
@@ -1691,7 +1707,7 @@ def find_errors(
         input_file (str): Path to the YAML file to check.
 
     Returns:
-        list[YAMLError]: List of YAMLError instances found in the file.
+        list[YAMLError]: List of findings found in the file.
     """
     with open(input_file, "r") as f:
         full_content = f.read()
@@ -1715,15 +1731,6 @@ def _collect_yaml_files(
     from dayamlchecker.code_formatter import _collect_yaml_files as _formatter_collect
 
     return _formatter_collect(paths, include_default_ignores=include_default_ignores)
-
-
-def _message_level(err_str: str) -> str:
-    lowered = err_str.lower()
-    if lowered.startswith("info:"):
-        return "info"
-    if lowered.startswith("warning:"):
-        return "warning"
-    return "error"
 
 
 def process_file(
@@ -1759,10 +1766,9 @@ def process_file(
     warning_count = 0
     info_count = 0
     for err in all_errors:
-        level = _message_level(err.err_str)
-        if level == "info":
+        if err.severity == "info":
             info_count += 1
-        elif level == "warning":
+        elif err.severity == "warning":
             warning_count += 1
         else:
             error_count += 1

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -1175,6 +1175,21 @@ def _yaml_error_message_id(error_text: str) -> str:
     return MessageId.YAML_PARSE_ERROR
 
 
+def _yaml_error_line_number(
+    error: MarkedYAMLError, full_content: str, default_line_number: int
+) -> int:
+    lines = full_content.splitlines()
+    for mark in (error.problem_mark, error.context_mark):
+        if mark is None:
+            continue
+        if 0 <= mark.line < len(lines) and lines[mark.line].strip():
+            return mark.line + 1
+    for mark in (error.problem_mark, error.context_mark):
+        if mark is not None:
+            return mark.line + 1
+    return default_line_number
+
+
 def _make_yaml_parser() -> YAML:
     yaml = YAML()
     yaml.allow_duplicate_keys = False
@@ -1554,16 +1569,20 @@ def find_errors_from_string(
         try:
             doc = _with_line_metadata(yaml_parser.load(source_code))
         except Exception as errMess:
+            error_line_number = line_number
             if isinstance(errMess, MarkedYAMLError):
                 if errMess.context_mark is not None:
                     errMess.context_mark.line += line_number - 1
                 if errMess.problem_mark is not None:
                     errMess.problem_mark.line += line_number - 1
+                error_line_number = _yaml_error_line_number(
+                    errMess, full_content, line_number
+                )
             rendered_error = str(errMess)
             all_errors.append(
                 make_finding(
                     _yaml_error_message_id(rendered_error),
-                    line_number=line_number,
+                    line_number=error_line_number,
                     file_name=input_file,
                     error=rendered_error,
                 )

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -1454,20 +1454,20 @@ def _find_unmatched_interview_order_references(
 
     guards_by_line = _extract_branch_guards_by_line(code)
     unmatched: list[tuple[str, int]] = []
-    seen_unmatched: set[tuple[str, int]] = set()
+    seen_fields: set[str] = set()
     for conditional in conditional_fields:
         field_var = conditional["field_var"]
+        if field_var in seen_fields:
+            continue
         expected_guards = conditional["guards"]
         for ref_line in _find_variable_reference_lines(code, field_var):
             active_guards = guards_by_line.get(ref_line, [])
             if _has_showifdef_guard(active_guards, field_var):
                 continue
             if not _has_matching_guard(active_guards, expected_guards):
-                key = (field_var, ref_line)
-                if key in seen_unmatched:
-                    continue
-                seen_unmatched.add(key)
-                unmatched.append(key)
+                seen_fields.add(field_var)
+                unmatched.append((field_var, ref_line))
+                break
     return unmatched
 
 

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -1454,6 +1454,7 @@ def _find_unmatched_interview_order_references(
 
     guards_by_line = _extract_branch_guards_by_line(code)
     unmatched: list[tuple[str, int]] = []
+    seen_unmatched: set[tuple[str, int]] = set()
     for conditional in conditional_fields:
         field_var = conditional["field_var"]
         expected_guards = conditional["guards"]
@@ -1462,7 +1463,11 @@ def _find_unmatched_interview_order_references(
             if _has_showifdef_guard(active_guards, field_var):
                 continue
             if not _has_matching_guard(active_guards, expected_guards):
-                unmatched.append((field_var, ref_line))
+                key = (field_var, ref_line)
+                if key in seen_unmatched:
+                    continue
+                seen_unmatched.add(key)
+                unmatched.append(key)
     return unmatched
 
 

--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -87,9 +87,7 @@ class YAMLStr:
     def __init__(self, x):
         self.errors = []
         if not isinstance(x, str):
-            self.errors = [
-                draft(MessageId.YAML_STRING_REQUIRED, value_repr=repr(x))
-            ]
+            self.errors = [draft(MessageId.YAML_STRING_REQUIRED, value_repr=repr(x))]
 
 
 class MakoText:
@@ -225,16 +223,16 @@ class PythonBool:
             return
         # must be a string at this point
         if not isinstance(x, str):
-            self.errors = [draft(MessageId.PYTHON_BOOL_TYPE, value_type=type(x).__name__)]
+            self.errors = [
+                draft(MessageId.PYTHON_BOOL_TYPE, value_type=type(x).__name__)
+            ]
             return
         # try parsing it as a Python expression - covers things like "user_age > 18"
         try:
             ast.parse(x)
         except SyntaxError as ex:
             msg = ex.msg or str(ex)
-            self.errors = [
-                draft(MessageId.PYTHON_BOOL_SYNTAX, value=x, error=msg)
-            ]
+            self.errors = [draft(MessageId.PYTHON_BOOL_SYNTAX, value=x, error=msg)]
 
 
 class JavascriptText:
@@ -322,8 +320,7 @@ class JSShowIf:
                         draft(
                             MessageId.JS_UNKNOWN_SCREEN_FIELD,
                             line_number=(
-                                call.get("loc", {}).get("start", {}).get("line", 1)
-                                or 1
+                                call.get("loc", {}).get("start", {}).get("line", 1) or 1
                             ),
                             modifier_key=modifier_key,
                             var_name=var_name,
@@ -397,9 +394,7 @@ class ShowIf:
                 pass
             elif x.startswith("variable:") or x.startswith("code:"):
                 # Malformed - these should be YAML dict format
-                self.errors.append(
-                    draft(MessageId.SHOW_IF_MALFORMED, value=x)
-                )
+                self.errors.append(draft(MessageId.SHOW_IF_MALFORMED, value=x))
         elif isinstance(x, dict):
             # YAML dict form
             if "variable" in x:
@@ -576,7 +571,9 @@ class DAFields:
                     self.errors.append(
                         draft(
                             MessageId.FIELD_MODIFIER_CODE_ERROR,
-                            line_number=self._line_for(field_item, err.line_number or 1),
+                            line_number=self._line_for(
+                                field_item, err.line_number or 1
+                            ),
                             modifier_key=modifier_key,
                             detail=err.message.lower(),
                         )

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -87,6 +87,28 @@ question: |
             _has_code(errs, "EG101"),
             f"Expected duplicate key error, got: {errs}",
         )
+        duplicate_key_error = next(e for e in errs if e.code == "EG101")
+        self.assertEqual(
+            duplicate_key_error.line_number,
+            4,
+            f"Expected duplicate key to point at the repeated key line, got: {duplicate_key_error}",
+        )
+
+    def test_yaml_parse_error_uses_exact_line_in_later_document(self):
+        invalid = """question: Hello
+---
+question: |
+  Hi
+fields
+  - name
+"""
+        errs = find_errors_from_string(invalid, input_file="<string_invalid>")
+        parse_error = next(e for e in errs if e.code == "EG102")
+        self.assertEqual(
+            parse_error.line_number,
+            5,
+            f"Expected parse error to point at the exact line in the later document, got: {parse_error}",
+        )
 
     def test_accessibility_mode_disabled_by_default(self):
         yaml_content = """question: |

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -573,6 +573,31 @@ fields:
             f"Did not expect no-label accessibility error for dynamic code field, got: {errs}",
         )
 
+    def test_accessibility_no_label_uses_variable_from_no_label_key(self):
+        yaml_content = """question: |
+  Reorder fields
+fields:
+  - note: |
+      Drag to reorder.
+  - no label: interview.questions[i].fld_order_list
+    datatype: draggable_tbl_order_list
+  - Another field: other_value
+"""
+        errs = find_errors_from_string(
+            yaml_content,
+            input_file="<string_invalid>",
+            lint_mode="accessibility",
+        )
+        self.assertTrue(
+            any(
+                e.code == "EA502"
+                and "interview.questions[i].fld_order_list" in e.err_str
+                and "<unknown field>" not in e.err_str
+                for e in errs
+            ),
+            f"Expected no-label accessibility error to include variable name, got: {errs}",
+        )
+
     def test_accessibility_tagged_pdf_info_for_docx_without_setting(self):
         yaml_content = """attachments:
   - name: Letter
@@ -1666,6 +1691,45 @@ code: |
                     any("without a matching guard" in e.err_str.lower() for e in errs),
                     f"Expected no interview-order guard error for {modifier}, got: {errs}",
                 )
+
+    def test_interview_order_duplicate_conditional_fields_only_report_once(self):
+        duplicated = """
+question: |
+  First screen
+fields:
+  - Reason: eviction_reason
+    choices:
+      - Nonpayment
+      - Other
+  - Other details: other_details
+    show if:
+      variable: eviction_reason
+      is: Other
+---
+question: |
+  Second screen
+fields:
+  - Reason again: eviction_reason
+    choices:
+      - Nonpayment
+      - Other
+  - Other details again: other_details
+    show if:
+      variable: eviction_reason
+      is: Other
+---
+id: interview_order
+mandatory: True
+code: |
+  other_details
+"""
+        errs = find_errors_from_string(duplicated, input_file="<string_invalid>")
+        guard_errors = [e for e in errs if e.code == "EG308"]
+        self.assertEqual(
+            len(guard_errors),
+            1,
+            f"Expected one deduplicated interview-order guard error, got: {guard_errors}",
+        )
 
     def test_show_hide_nesting_depth_over_two_warns(self):
         """Warn when a single page has show/hide dependency depth greater than two"""

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -1731,6 +1731,32 @@ code: |
             f"Expected one deduplicated interview-order guard error, got: {guard_errors}",
         )
 
+    def test_interview_order_repeated_same_variable_only_reports_once(self):
+        repeated = """
+question: |
+  Relationship
+fields:
+  - Relationship detail: relationship_detail
+    show if:
+      variable: married
+      is: True
+---
+id: interview_order
+mandatory: True
+code: |
+  if married:
+    relationship_detail = "first"
+  relationship_detail += " second"
+  relationship_detail = relationship_detail.strip()
+"""
+        errs = find_errors_from_string(repeated, input_file="<string_invalid>")
+        guard_errors = [e for e in errs if e.code == "EG308"]
+        self.assertEqual(
+            len(guard_errors),
+            1,
+            f"Expected one interview-order guard error for repeated references, got: {guard_errors}",
+        )
+
     def test_show_hide_nesting_depth_over_two_warns(self):
         """Warn when a single page has show/hide dependency depth greater than two"""
         warning_yaml = """

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -252,11 +252,7 @@ subquestion: |
             input_file="<string_invalid>",
             lint_mode="accessibility",
         )
-        heading_error = next(
-            e
-            for e in errs
-            if e.code == "EA506"
-        )
+        heading_error = next(e for e in errs if e.code == "EA506")
         self.assertEqual(
             heading_error.line_number,
             7,
@@ -589,8 +585,7 @@ fields:
         )
         self.assertTrue(
             any(
-                e.code == "IA503"
-                and "docx attachment detected" in e.err_str.lower()
+                e.code == "IA503" and "docx attachment detected" in e.err_str.lower()
                 for e in errs
             ),
             f"Expected tagged-pdf info note, got: {errs}",
@@ -1461,11 +1456,7 @@ fields:
 continue button field: interrogatory_questions
 """
         errs = find_errors_from_string(valid, input_file="<string_valid>")
-        field_errors = [
-            e
-            for e in errs
-            if e.code in {"EG405", "EG406"}
-        ]
+        field_errors = [e for e in errs if e.code in {"EG405", "EG406"}]
         self.assertEqual(
             len(field_errors),
             0,
@@ -1488,7 +1479,8 @@ continue button field: interrogatory_questions
         field_errors = [
             e
             for e in errs
-            if e.code == "EG111" and "default value has (indentationerror)" in e.err_str.lower()
+            if e.code == "EG111"
+            and "default value has (indentationerror)" in e.err_str.lower()
         ]
         self.assertEqual(
             len(field_errors),

--- a/tests/test_yaml_structure.py
+++ b/tests/test_yaml_structure.py
@@ -4,6 +4,10 @@ from tempfile import TemporaryDirectory
 from dayamlchecker.yaml_structure import RuntimeOptions, find_errors_from_string
 
 
+def _has_code(errs, code: str) -> bool:
+    return any(err.code == code for err in errs)
+
+
 class TestYAMLStructure(unittest.TestCase):
     def test_valid_question_no_errors(self):
         valid = """
@@ -23,7 +27,7 @@ template: |
 """
         errs = find_errors_from_string(invalid, input_file="<string_invalid>")
         self.assertTrue(
-            any("Too many types this block could be" in e.err_str for e in errs),
+            _has_code(errs, "EG307"),
             f"Expected exclusivity error, got: {errs}",
         )
 
@@ -33,11 +37,7 @@ foo: bar
 """
         errs = find_errors_from_string(invalid, input_file="<string_invalid>")
         self.assertTrue(
-            any(
-                "Couldn't identify a block type: no valid combination of keys found"
-                in e.err_str
-                for e in errs
-            ),
+            _has_code(errs, "EG306"),
             f"Expected clearer unknown block type error, got: {errs}",
         )
 
@@ -64,7 +64,8 @@ fields:
         errs = find_errors_from_string(invalid, input_file="<string_invalid>")
         self.assertTrue(
             any(
-                'Invalid field key "Show If"' in e.err_str
+                e.code == "EG413"
+                and 'invalid field key "show if"' in e.err_str.lower()
                 and 'use "show if"' in e.err_str
                 for e in errs
             ),
@@ -83,11 +84,7 @@ question: |
             len(errs) > 0, f"Expected parser error for duplicate keys, got: {errs}"
         )
         self.assertTrue(
-            any(
-                "duplicate key" in e.err_str.lower()
-                or "found duplicate key" in e.err_str.lower()
-                for e in errs
-            ),
+            _has_code(errs, "EG101"),
             f"Expected duplicate key error, got: {errs}",
         )
 
@@ -96,9 +93,7 @@ question: |
   ![](docassemble.demo:data/static/logo.png)
 """
         errs = find_errors_from_string(yaml_content, input_file="<string_valid>")
-        accessibility_errors = [
-            e for e in errs if "accessibility:" in e.err_str.lower()
-        ]
+        accessibility_errors = [e for e in errs if e.finding_class == "accessibility"]
         self.assertEqual(
             len(accessibility_errors),
             0,
@@ -116,7 +111,8 @@ question: |
         )
         self.assertTrue(
             any(
-                "accessibility: markdown image" in e.err_str.lower()
+                e.code == "EA505"
+                and "markdown image" in e.err_str.lower()
                 and "missing alt text" in e.err_str.lower()
                 for e in errs
             ),
@@ -134,7 +130,8 @@ question: |
         )
         self.assertTrue(
             any(
-                "accessibility: [file ...] image" in e.err_str.lower()
+                e.code == "EA505"
+                and "[file ...] image" in e.err_str.lower()
                 and "missing alt text" in e.err_str.lower()
                 for e in errs
             ),
@@ -170,7 +167,8 @@ question: |
         )
         self.assertTrue(
             any(
-                "accessibility: html image" in e.err_str.lower()
+                e.code == "EA505"
+                and "html image" in e.err_str.lower()
                 and "missing alt text" in e.err_str.lower()
                 for e in errs
             ),
@@ -191,8 +189,8 @@ subquestion: |
         )
         self.assertTrue(
             any(
-                "accessibility: markdown heading levels skip from h2 to h4"
-                in e.err_str.lower()
+                e.code == "EA506"
+                and "markdown heading levels skip from h2 to h4" in e.err_str.lower()
                 for e in errs
             ),
             f"Expected markdown heading-order accessibility error, got: {errs}",
@@ -212,8 +210,8 @@ subquestion: |
         )
         self.assertTrue(
             any(
-                "accessibility: html heading levels skip from h2 to h4"
-                in e.err_str.lower()
+                e.code == "EA507"
+                and "html heading levels skip from h2 to h4" in e.err_str.lower()
                 for e in errs
             ),
             f"Expected HTML heading-order accessibility error, got: {errs}",
@@ -233,9 +231,7 @@ subquestion: |
             input_file="<string_valid>",
             lint_mode="accessibility",
         )
-        accessibility_errors = [
-            e for e in errs if "accessibility:" in e.err_str.lower()
-        ]
+        accessibility_errors = [e for e in errs if e.finding_class == "accessibility"]
         self.assertEqual(
             len(accessibility_errors),
             0,
@@ -259,7 +255,7 @@ subquestion: |
         heading_error = next(
             e
             for e in errs
-            if "accessibility: markdown heading levels skip" in e.err_str.lower()
+            if e.code == "EA506"
         )
         self.assertEqual(
             heading_error.line_number,
@@ -277,9 +273,7 @@ subquestion: |
             input_file="<string_valid>",
             lint_mode="accessibility",
         )
-        structural_errors = [
-            e for e in errs if "accessibility:" not in e.err_str.lower()
-        ]
+        structural_errors = [e for e in errs if e.finding_class != "accessibility"]
         self.assertGreater(
             len(structural_errors),
             0,
@@ -302,11 +296,7 @@ comment: |
 """
         errs = find_errors_from_string(yaml_content, input_file="<string_invalid>")
         self.assertTrue(
-            any(
-                "couldn't identify a block type: no valid combination of keys found"
-                in e.err_str.lower()
-                for e in errs
-            ),
+            _has_code(errs, "EG306"),
             f"Expected comment+id no-type validation error, got: {errs}",
         )
 
@@ -317,11 +307,7 @@ ga id: comment_block
 """
         errs = find_errors_from_string(yaml_content, input_file="<string_invalid>")
         self.assertTrue(
-            any(
-                "couldn't identify a block type: no valid combination of keys found"
-                in e.err_str.lower()
-                for e in errs
-            ),
+            _has_code(errs, "EG306"),
             f"Expected comment+ga id no-type validation error, got: {errs}",
         )
 
@@ -332,11 +318,7 @@ mandatory: True
 """
         errs = find_errors_from_string(yaml_content, input_file="<string_invalid>")
         self.assertTrue(
-            any(
-                "couldn't identify a block type: no valid combination of keys found"
-                in e.err_str.lower()
-                for e in errs
-            ),
+            _has_code(errs, "EG306"),
             f"Expected comment+mandatory no-type validation error, got: {errs}",
         )
 
@@ -392,8 +374,8 @@ fields:
         )
         self.assertTrue(
             any(
-                "datatype: combobox" in e.err_str.lower()
-                and "accessibility:" in e.err_str.lower()
+                e.code == "EA501"
+                and 'field "option" uses `combobox`' in e.err_str.lower()
                 for e in errs
             ),
             f"Expected combobox accessibility error, got: {errs}",
@@ -607,7 +589,7 @@ fields:
         )
         self.assertTrue(
             any(
-                e.err_str.lower().startswith("info:")
+                e.code == "IA503"
                 and "docx attachment detected" in e.err_str.lower()
                 for e in errs
             ),
@@ -794,7 +776,7 @@ fields:
         errs = find_errors_from_string(warning_yaml, input_file="<string_warn>")
         self.assertTrue(
             any(
-                e.err_str.lower().startswith("warning:")
+                e.code == "WG206"
                 and "unable to fully validate screen variables" in e.err_str.lower()
                 for e in errs
             ),
@@ -1482,8 +1464,7 @@ continue button field: interrogatory_questions
         field_errors = [
             e
             for e in errs
-            if "fields should be a list" in e.err_str.lower()
-            or "fields dict must have" in e.err_str.lower()
+            if e.code in {"EG405", "EG406"}
         ]
         self.assertEqual(
             len(field_errors),
@@ -1507,7 +1488,7 @@ continue button field: interrogatory_questions
         field_errors = [
             e
             for e in errs
-            if "default value has (indentationerror)" in e.err_str.lower()
+            if e.code == "EG111" and "default value has (indentationerror)" in e.err_str.lower()
         ]
         self.assertEqual(
             len(field_errors),

--- a/tests/test_yaml_structure_cli.py
+++ b/tests/test_yaml_structure_cli.py
@@ -124,7 +124,8 @@ def test_main_default_wcag_reports_failures():
         output = stdout.getvalue().lower()
         assert exit_code == 1
         assert "found 1 errors" in output
-        assert "accessibility: markdown image" in output
+        assert "[ea505]" in output
+        assert "markdown image" in output
 
 
 def test_main_wcag_info_only_does_not_fail():
@@ -144,7 +145,8 @@ def test_main_wcag_info_only_does_not_fail():
 
         output = stdout.getvalue().lower()
         assert exit_code == 0
-        assert "info: accessibility: docx attachment detected" in output
+        assert "[ia503]" in output
+        assert "docx attachment detected" in output
 
 
 def test_main_warning_still_fails_outside_info_only_mode():
@@ -173,7 +175,7 @@ def test_main_warning_still_fails_outside_info_only_mode():
 
         output = stdout.getvalue().lower()
         assert exit_code == 1
-        assert "warning:" in output
+        assert "[wg206]" in output
 
 
 def test_main_combobox_widget_check_disabled_by_default():
@@ -233,7 +235,7 @@ def test_main_invokes_url_checker_with_default_severities(monkeypatch, capsys):
                 checked_url_count=1,
                 ignored_url_count=0,
                 issues=(
-                    URLIssue(
+                    URLIssue.create(
                         severity="warning",
                         category="broken",
                         source_kind="template",
@@ -302,7 +304,7 @@ def test_main_fails_on_url_checker_errors(monkeypatch, capsys):
                 checked_url_count=1,
                 ignored_url_count=0,
                 issues=(
-                    URLIssue(
+                    URLIssue.create(
                         severity="error",
                         category="broken",
                         source_kind="yaml",


### PR DESCRIPTION
Fix #14 

Uses stable message strings, roughly grouped by the kind of finding, and explicitly sets up different severity classes.

To the extent possible, I tried to harmonize with the message classes used by @jpagh's branch.

## Summary
- move finding metadata into a single shared messages module with stable severity/class-based codes
- refactor YAML, accessibility, and URL checks to emit structured findings from the catalog
- update CLI and tests for the new coded findings

