### PR TITLE
Close #72, add `depends on` as valid key

### DIFF
--- a/src/dayamlchecker/yaml_structure.py
+++ b/src/dayamlchecker/yaml_structure.py
@@ -1065,6 +1065,7 @@ big_dict: dict[str, dict[str, Any]] = {
     "content": {},
     "reconsider": {},
     "depends on": {},
+    "depends on": {},
     "need": {},
     "attachment": {},
     "table": {},


### PR DESCRIPTION
My mistake, I can close. My workflow has been failing, though:

https://github.com/SuffolkLITLab/docassemble-ALKilnSetup/actions/runs/31503848240/job/93820338136#step:3:509